### PR TITLE
fix: fix health check for queue worker to get its correct status

### DIFF
--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -112,17 +112,11 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: |
-        # Check if queue worker process is running and ready marker exists
-        if [ -f /var/www/html/storage/laravel_ready ] && pgrep -f "queue:work" >/dev/null; then
-          exit 0
-        else
-          exit 1
-        fi
+      test: ["CMD", "sh", "-c", "[ -f /var/www/html/storage/laravel_ready ] && grep -q queue:work /proc/*/cmdline"]
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 360s  # Give 6 minutes for main app setup + queue worker startup
+      start_period: 60s  # Give 1 minute for queue worker startup since main app is already ready
     networks:
       - laravel_blog_api_network
 


### PR DESCRIPTION
This pull request includes updates to the health check configuration for the `redis` service in the `docker-compose.yml` file. The changes streamline the health check logic and reduce the startup waiting period.

### Updates to health check configuration:

* Simplified the `test` command for the health check by replacing a multi-line script with a single `CMD` array that checks for the readiness marker and the queue worker process using `sh` and `grep`.
* Reduced the `start_period` from 360 seconds to 60 seconds, optimizing the startup time since the main application is already prepared.