### PR TITLE
Fix/scripts makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,32 +144,46 @@ docker-restart: docker-down docker-up
 # Testing Environment
 # =============================================================================
 
+
 # Run tests (automated testing environment)
-test: docker-setup-env
-	@echo "🧪 TESTING: Running complete test suite..."
-	cd containers && docker-compose -f docker-compose.test.yml up -d
-	@echo ">> Installing dependencies in test container..."
-	@sleep 10
-	docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test composer install --no-interaction --prefer-dist --optimize-autoloader
-	docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan key:generate --env=testing --force
-	docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan migrate:fresh --seed --env=testing --force
-	@echo ">> Running tests..."
-	docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan test --parallel --recreate-databases --stop-on-failure
-	cd containers && docker-compose -f docker-compose.test.yml down
-	@echo "✅ SUCCESS: Tests completed!"
+test:
+	@if docker-compose -f containers/docker-compose.test.yml ps | grep -q 'laravel_blog_api_test' && docker-compose -f containers/docker-compose.test.yml ps | grep 'Up'; then \
+		echo "🧪 TESTING: Test container already running. Skipping setup..."; \
+		echo ">> Running tests..."; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan test --parallel --recreate-databases --stop-on-failure; \
+		echo "✅ SUCCESS: Tests completed!"; \
+	else \
+		echo "🧪 TESTING: Running complete test suite..."; \
+		cd containers && docker-compose -f docker-compose.test.yml up -d; \
+		echo ">> Installing dependencies in test container..."; \
+		sleep 10; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test composer install --no-interaction --prefer-dist --optimize-autoloader; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan key:generate --env=testing --force; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan migrate:fresh --seed --env=testing --force; \
+		echo ">> Running tests..."; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan test --parallel --recreate-databases --stop-on-failure; \
+		echo "✅ SUCCESS: Tests completed!"; \
+	fi
+
 
 # Run tests with coverage report
-test-coverage: docker-setup-env
-	@echo "🧪 TESTING: Running tests with coverage..."
-	cd containers && docker-compose -f docker-compose.test.yml up -d
-	@sleep 10
-	docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test composer install --no-interaction --prefer-dist --optimize-autoloader
-	docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan key:generate --env=testing --force
-	docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan migrate:fresh --seed --env=testing --force
-	@echo ">> Running tests with coverage..."
-	docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan test --coverage --coverage-html reports/coverage --coverage-clover reports/coverage.xml --stop-on-failure --min=80
-	cd containers && docker-compose -f docker-compose.test.yml down
-	@echo "✅ SUCCESS: Tests with coverage completed!"
+test-coverage:
+	@if docker-compose -f containers/docker-compose.test.yml ps | grep -q 'laravel_blog_api_test' && docker-compose -f containers/docker-compose.test.yml ps | grep 'Up'; then \
+		echo "🧪 TESTING: Test container already running. Skipping setup..."; \
+		echo ">> Running tests with coverage..."; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan test --coverage --coverage-html reports/coverage --coverage-clover reports/coverage.xml --stop-on-failure --min=80; \
+		echo "✅ SUCCESS: Tests with coverage completed!"; \
+	else \
+		echo "🧪 TESTING: Running tests with coverage..."; \
+		cd containers && docker-compose -f docker-compose.test.yml up -d; \
+		sleep 10; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test composer install --no-interaction --prefer-dist --optimize-autoloader; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan key:generate --env=testing --force; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan migrate:fresh --seed --env=testing --force; \
+		echo ">> Running tests with coverage..."; \
+		docker-compose -f containers/docker-compose.test.yml exec -T laravel_blog_api_test php artisan test --coverage --coverage-html reports/coverage --coverage-clover reports/coverage.xml --stop-on-failure --min=80; \
+		echo "✅ SUCCESS: Tests with coverage completed!"; \
+	fi
 
 # =============================================================================
 # Code Quality Tools

--- a/containers/check-ports.sh
+++ b/containers/check-ports.sh
@@ -46,34 +46,29 @@ check_port() {
     local optional=${3:-false}
     local os=$(detect_os)
     local port_in_use=false
-
     case $os in
         "windows")
-            # Use netstat on Windows (available by default)
-            if netstat -an | grep -q ":$port "; then
+            # Only consider LISTENING state
+            if netstat -an | grep -E ":$port[[:space:]]" | grep -iq "LISTEN"; then
                 port_in_use=true
             fi
             ;;
         "macos")
-            # Use netstat on macOS (available by default)
-            if netstat -an | grep -q "\\.$port "; then
+            # Only consider LISTEN state
+            if netstat -an | grep -E "\.$port[[:space:]]" | grep -iq "LISTEN"; then
                 port_in_use=true
             fi
             ;;
         "linux")
-            # Try multiple methods on Linux
             if command -v ss &> /dev/null; then
-                # Use ss (modern replacement for netstat)
-                if ss -tuln | grep -q ":$port "; then
+                if ss -tuln | awk '{print $4,$1}' | grep -E "[:.]$port[[:space:]]" | grep -iq "LISTEN"; then
                     port_in_use=true
                 fi
             elif command -v netstat &> /dev/null; then
-                # Fall back to netstat
-                if netstat -tuln | grep -q ":$port "; then
+                if netstat -tuln | grep -E ":$port[[:space:]]" | grep -iq "LISTEN"; then
                     port_in_use=true
                 fi
             elif command -v nc &> /dev/null; then
-                # Fall back to netcat
                 if nc -z localhost $port 2>/dev/null; then
                     port_in_use=true
                 fi
@@ -83,7 +78,6 @@ check_port() {
             fi
             ;;
         *)
-            # Unknown OS - try netcat if available
             if command -v nc &> /dev/null; then
                 if nc -z localhost $port 2>/dev/null; then
                     port_in_use=true


### PR DESCRIPTION
This pull request includes updates to streamline Docker-based testing workflows and enhance port-checking scripts for better reliability and clarity. The key changes include improving test container handling in the `Makefile` and refining port-checking logic across multiple scripts.

### Docker-based testing improvements:
* Updated the `test` and `test-coverage` targets in the `Makefile` to check if the test container is already running before setting it up, reducing unnecessary overhead. This change ensures the workflow is more efficient by skipping redundant setup steps when the container is already active.

### Port-checking logic enhancements:
* Modified the `check_port()` function in `containers/check-ports.sh` and `containers/check-sonarqube-ports.sh` to only consider ports in the "LISTEN" state when determining if a port is in use. This change improves accuracy by excluding irrelevant states. [[1]](diffhunk://#diff-572807e71f638f397bd52623f306f9b05b8533d0a1e32d2aef2b1a174b99befbL49-L76) [[2]](diffhunk://#diff-16a7cd845687dab348ba70cb3becbe067a3cdb2d868a1c8a8708d82c647cda97R37-L66)
* Added a `return 0` statement in the `check_port()` function of `containers/check-sonarqube-ports.sh` to ensure proper early exit when a port is available.
