### PR TITLE
Feature/get articles api

### DIFF
--- a/app/Http/Controllers/Api/V1/Article/GetArticlesController.php
+++ b/app/Http/Controllers/Api/V1/Article/GetArticlesController.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Article;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Article\GetArticlesRequest;
+use App\Http\Resources\Api\V1\Article\ArticleResource;
+use App\Services\ArticleService;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Group('Articles', weight: 1)]
+class GetArticlesController extends Controller
+{
+    public function __construct(
+        private readonly ArticleService $articleService
+    ) {}
+
+    /**
+     * Get Articles List
+     *
+     * Retrieve a paginated list of articles with optional filtering by category, tags, author, and search terms
+     *
+     * @unauthenticated
+     *
+     * @response array{status: true, message: string, data: array{data: ArticleResource[], links: array, meta: array}}
+     */
+    public function __invoke(GetArticlesRequest $request): JsonResponse
+    {
+        try {
+            $params = $request->withDefaults();
+
+            $articles = $this->articleService->getArticles($params);
+
+            $articleCollection = ArticleResource::collection($articles);
+
+            /**
+             * Successful articles retrieval
+             */
+            $articleCollectionData = $articleCollection->response()->getData(true);
+
+            // Ensure we have the expected array structure
+            if (! is_array($articleCollectionData) || ! isset($articleCollectionData['data'], $articleCollectionData['meta'])) {
+                throw new \RuntimeException('Unexpected response format from ArticleResource collection');
+            }
+
+            return response()->apiSuccess(
+                [
+                    'articles' => $articleCollectionData['data'],
+                    'meta' => $articleCollectionData['meta'],
+                ],
+                __('common.success')
+            );
+        } catch (\Throwable $e) {
+            /**
+             * Internal server error
+             *
+             * @status 500
+             *
+             * @body array{status: false, message: string, data: null, error: null}
+             */
+            return response()->apiError(
+                __('common.something_went_wrong'),
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/Article/ShowArticleController.php
+++ b/app/Http/Controllers/Api/V1/Article/ShowArticleController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Article;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\Article\ArticleResource;
+use App\Services\ArticleService;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Group('Articles', weight: 1)]
+class ShowArticleController extends Controller
+{
+    public function __construct(
+        private readonly ArticleService $articleService
+    ) {}
+
+    /**
+     * Get Article by Slug
+     *
+     * Retrieve a specific article by its slug identifier
+     *
+     * @unauthenticated
+     *
+     * @response array{status: true, message: string, data: ArticleResource}
+     */
+    public function __invoke(string $slug): JsonResponse
+    {
+        try {
+            $article = $this->articleService->getArticleBySlug($slug);
+
+            /**
+             * Successful article retrieval
+             */
+            return response()->apiSuccess(
+                new ArticleResource($article),
+                __('common.success')
+            );
+        } catch (ModelNotFoundException $e) {
+            /**
+             * Article not found
+             *
+             * @status 404
+             *
+             * @body array{status: false, message: string, data: null, error: null}
+             */
+            return response()->apiError(
+                __('common.not_found'),
+                Response::HTTP_NOT_FOUND
+            );
+        } catch (\Throwable $e) {
+            /**
+             * Internal server error
+             *
+             * @status 500
+             *
+             * @body array{status: false, message: string, data: null, error: null}
+             */
+            return response()->apiError(
+                __('common.something_went_wrong'),
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+}

--- a/app/Http/Requests/Api/V1/Article/GetArticlesRequest.php
+++ b/app/Http/Requests/Api/V1/Article/GetArticlesRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1\Article;
+
+use App\Enums\ArticleStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class GetArticlesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'page' => ['integer', 'min:1'],
+            'per_page' => ['integer', 'min:1', 'max:100'],
+            'search' => ['string', 'max:255'],
+            'status' => [Rule::enum(ArticleStatus::class)],
+            'category_slug' => ['string'],
+            'category_slug.*' => ['string', 'exists:categories,slug'],
+            'tag_slug' => ['string'],
+            'tag_slug.*' => ['string', 'exists:tags,slug'],
+            'author_id' => ['integer', 'exists:users,id'],
+            'created_by' => ['integer', 'exists:users,id'],
+            'published_after' => ['date'],
+            'published_before' => ['date'],
+            'sort_by' => [Rule::in(['title', 'published_at', 'created_at', 'updated_at'])],
+            'sort_direction' => [Rule::in(['asc', 'desc'])],
+        ];
+    }
+
+    /**
+     * Get the default values for missing parameters
+     *
+     * @return array<string, mixed>
+     */
+    public function withDefaults(): array
+    {
+        return array_merge([
+            'page' => 1,
+            'per_page' => 15,
+            'sort_by' => 'published_at',
+            'sort_direction' => 'desc',
+            'status' => ArticleStatus::PUBLISHED->value,
+        ], $this->validated());
+    }
+}

--- a/app/Http/Resources/Api/V1/Article/ArticleResource.php
+++ b/app/Http/Resources/Api/V1/Article/ArticleResource.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1\Article;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Article
+ */
+class ArticleResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'title' => $this->title,
+            'subtitle' => $this->subtitle,
+            'excerpt' => $this->excerpt,
+            'content_html' => $this->content_html,
+            'content_markdown' => $this->content_markdown,
+            'featured_image' => $this->featured_image,
+            'status' => $this->status,
+            'published_at' => $this->published_at?->toISOString(),
+            'meta_title' => $this->meta_title,
+            'meta_description' => $this->meta_description,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+
+            // Relationships
+            'author' => $this->whenLoaded('author', function () {
+                return $this->author ? [
+                    'id' => $this->author->id,
+                    'name' => $this->author->name,
+                    'email' => $this->author->email,
+                    'avatar_url' => $this->author->avatar_url,
+                    'bio' => $this->author->bio,
+                ] : null;
+            }),
+
+            'categories' => $this->whenLoaded('categories', function () {
+                /** @var \Illuminate\Database\Eloquent\Collection<int, \App\Models\Category> $categories */
+                $categories = $this->categories;
+
+                return $categories->map(function ($category) {
+                    return [
+                        'id' => $category->id,
+                        'name' => $category->name,
+                        'slug' => $category->slug,
+                    ];
+                })->values()->all();
+            }),
+
+            'tags' => $this->whenLoaded('tags', function () {
+                /** @var \Illuminate\Database\Eloquent\Collection<int, \App\Models\Tag> $tags */
+                $tags = $this->tags;
+
+                return $tags->map(function ($tag) {
+                    return [
+                        'id' => $tag->id,
+                        'name' => $tag->name,
+                        'slug' => $tag->slug,
+                    ];
+                })->values()->all();
+            }),
+
+            'authors' => $this->whenLoaded('authors', function () {
+                /** @var \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $authors */
+                $authors = $this->authors;
+
+                return $authors->map(function ($author) {
+                    /** @var \Illuminate\Database\Eloquent\Relations\Pivot|null $pivot */
+                    $pivot = $author->getAttribute('pivot');
+
+                    return [
+                        'id' => $author->id,
+                        'name' => $author->name,
+                        'email' => $author->email,
+                        'avatar_url' => $author->avatar_url,
+                        'bio' => $author->bio,
+                        'role' => $pivot?->getAttribute('role'),
+                    ];
+                })->values()->all();
+            }),
+
+            'comments_count' => $this->whenCounted('comments'),
+        ];
+    }
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -8,6 +8,7 @@ use App\Enums\ArticleStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
@@ -80,5 +81,29 @@ final class Article extends Model
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /**
+     * @return BelongsToMany<Category,Article>
+     */
+    public function categories(): BelongsToMany
+    {
+        return $this->belongsToMany(Category::class, 'article_categories');
+    }
+
+    /**
+     * @return BelongsToMany<Tag,Article>
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'article_tags');
+    }
+
+    /**
+     * @return BelongsToMany<User,Article>
+     */
+    public function authors(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'article_authors')->withPivot('role');
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -6,7 +6,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @property int $id
@@ -34,10 +34,10 @@ final class Category extends Model
     }
 
     /**
-     * @return HasMany<ArticleCategory,Category>
+     * @return BelongsToMany<Article,Category>
      */
-    public function articles(): HasMany
+    public function articles(): BelongsToMany
     {
-        return $this->hasMany(ArticleCategory::class);
+        return $this->belongsToMany(Article::class, 'article_categories');
     }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @property int $id
@@ -32,5 +33,13 @@ final class Tag extends Model
     protected function casts(): array
     {
         return [];
+    }
+
+    /**
+     * @return BelongsToMany<Article,Tag>
+     */
+    public function articles(): BelongsToMany
+    {
+        return $this->belongsToMany(Article::class, 'article_tags');
     }
 }

--- a/app/Services/ArticleService.php
+++ b/app/Services/ArticleService.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Article;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class ArticleService
+{
+    /**
+     * Get articles with filters and pagination
+     *
+     * @param  array<string, mixed>  $params
+     * @return LengthAwarePaginator<int, Article>
+     */
+    public function getArticles(array $params): LengthAwarePaginator
+    {
+        $query = Article::query()
+            ->with(['author:id,name,email,avatar_url,bio', 'categories:id,name,slug', 'tags:id,name,slug'])
+            ->withCount('comments');
+
+        // Apply filters
+        $this->applyFilters($query, $params);
+
+        // Apply sorting
+        $query->orderBy($params['sort_by'], $params['sort_direction']);
+
+        // Apply pagination
+        return $query->paginate($params['per_page'], ['*'], 'page', $params['page']);
+    }
+
+    /**
+     * Get a single article by slug
+     */
+    public function getArticleBySlug(string $slug): Article
+    {
+        return Article::query()
+            ->with([
+                'author:id,name,email,avatar_url,bio,twitter,facebook,linkedin,github,website',
+                'categories:id,name,slug',
+                'tags:id,name,slug',
+                'authors:id,name,email,avatar_url,bio',
+            ])
+            ->withCount('comments')
+            ->where('slug', $slug)
+            ->firstOrFail();
+    }
+
+    /**
+     * Apply filters to the query
+     *
+     * @param  Builder<Article>  $query
+     * @param  array<string, mixed>  $params
+     */
+    private function applyFilters(Builder $query, array $params): void
+    {
+        // Search in title, subtitle, excerpt, and content
+        if (! empty($params['search'])) {
+            $searchTerm = (string) $params['search'];
+            $query->where(function (Builder $q) use ($searchTerm) {
+                $q->where('title', 'like', "%{$searchTerm}%")
+                    ->orWhere('subtitle', 'like', "%{$searchTerm}%")
+                    ->orWhere('excerpt', 'like', "%{$searchTerm}%")
+                    ->orWhere('content_markdown', 'like', "%{$searchTerm}%");
+            });
+        }
+
+        // Filter by status
+        if (! empty($params['status'])) {
+            $query->where('status', $params['status']);
+        }
+
+        // Filter by categories (support multiple categories)
+        if (! empty($params['category_slug'])) {
+            $categorySlugs = is_array($params['category_slug'])
+                ? $params['category_slug']
+                : [$params['category_slug']];
+
+            $query->whereHas('categories', function (Builder $q) use ($categorySlugs) {
+                $q->whereIn('slug', $categorySlugs);
+            });
+        }
+
+        // Filter by tags (support multiple tags)
+        if (! empty($params['tag_slug'])) {
+            $tagSlugs = is_array($params['tag_slug'])
+                ? $params['tag_slug']
+                : [$params['tag_slug']];
+
+            $query->whereHas('tags', function (Builder $q) use ($tagSlugs) {
+                $q->whereIn('slug', $tagSlugs);
+            });
+        }
+
+        // Filter by author (from article_authors table)
+        if (! empty($params['author_id'])) {
+            $query->whereHas('authors', function (Builder $q) use ($params) {
+                $q->where('user_id', $params['author_id']);
+            });
+        }
+
+        // Filter by creator
+        if (! empty($params['created_by'])) {
+            $query->where('created_by', $params['created_by']);
+        }
+
+        // Filter by publication date range
+        if (! empty($params['published_after'])) {
+            $query->where('published_at', '>=', $params['published_after']);
+        }
+
+        if (! empty($params['published_before'])) {
+            $query->where('published_at', '<=', $params['published_before']);
+        }
+
+        // Only include published articles for public access (unless specifically querying other statuses)
+        if (empty($params['status'])) {
+            $query->where('status', 'published')
+                ->whereNotNull('published_at')
+                ->where('published_at', '<=', now());
+        }
+    }
+}

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -12,4 +12,5 @@ return [
 
     'something_went_wrong' => 'Something went wrong! Try again later.',
     'success' => 'Response returned successfully.',
+    'not_found' => 'Resource not found.',
 ];

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -8,16 +8,20 @@ Route::prefix('v1')->group(function () {
         return 'Laravel Blog API V1 Root is working';
     })->name('api.v1.status');
 
-    // Auth
+    // Auth Routes
     Route::post('/auth/login', \App\Http\Controllers\Api\V1\Auth\LoginController::class)->name('api.v1.auth.login');
     Route::post('/auth/refresh', \App\Http\Controllers\Api\V1\Auth\RefreshTokenController::class)->name('api.v1.auth.refresh');
-
-    Route::middleware(['auth:sanctum', 'ability:access-api'])->group(function () {
-        Route::post('/auth/logout', \App\Http\Controllers\Api\V1\Auth\LogoutController::class)->name('api.v1.auth.logout');
-    });
 
     // User Routes
     Route::middleware(['auth:sanctum', 'ability:access-api'])->group(function () {
         Route::get('/me', \App\Http\Controllers\Api\V1\User\MeController::class);
+
+        Route::post('/auth/logout', \App\Http\Controllers\Api\V1\Auth\LogoutController::class)->name('api.v1.auth.logout');
+    });
+
+    // Article Routes (Public)
+    Route::prefix('articles')->group(function () {
+        Route::get('/', \App\Http\Controllers\Api\V1\Article\GetArticlesController::class)->name('api.v1.articles.index');
+        Route::get('/{slug}', \App\Http\Controllers\Api\V1\Article\ShowArticleController::class)->name('api.v1.articles.show');
     });
 });

--- a/tests/Feature/API/V1/Article/GetArticlesControllerTest.php
+++ b/tests/Feature/API/V1/Article/GetArticlesControllerTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Article;
+use App\Models\Category;
+use App\Models\Tag;
+use App\Models\User;
+
+describe('API/V1/Article/GetArticlesController', function () {
+    it('can get articles with basic pagination', function () {
+        // Create test data
+        $user = User::factory()->create();
+        $articles = Article::factory()
+            ->count(25)
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $response = $this->getJson('/api/v1/articles');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'data' => [
+                    'articles' => [
+                        '*' => [
+                            'id',
+                            'slug',
+                            'title',
+                            'subtitle',
+                            'excerpt',
+                            'featured_image',
+                            'status',
+                            'published_at',
+                            'created_at',
+                            'updated_at',
+                            'author' => [
+                                'id',
+                                'name',
+                                'avatar_url',
+                            ],
+                            'categories',
+                            'tags',
+                            'comments_count',
+                        ],
+                    ],
+                    'meta',
+                ],
+            ]);
+
+        // Should return 15 articles per page by default
+        expect($response->json('data.articles'))->toHaveCount(15);
+    });
+
+    it('can filter articles by category', function () {
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+
+        // Create article with category
+        $article = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $article->categories()->attach($category->id);
+
+        // Create article without category
+        Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $response = $this->getJson("/api/v1/articles?category_slug={$category->slug}");
+
+        $response->assertStatus(200);
+        expect($response->json('data.articles'))->toHaveCount(1);
+        expect($response->json('data.articles.0.id'))->toBe($article->id);
+    });
+
+    it('can filter articles by tag', function () {
+        $user = User::factory()->create();
+        $tag = Tag::factory()->create();
+
+        // Create article with tag
+        $article = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $article->tags()->attach($tag->id);
+
+        // Create article without tag
+        Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $response = $this->getJson("/api/v1/articles?tag_slug={$tag->slug}");
+
+        $response->assertStatus(200);
+        expect($response->json('data.articles'))->toHaveCount(1);
+        expect($response->json('data.articles.0.id'))->toBe($article->id);
+    });
+
+    it('can search articles', function () {
+        $user = User::factory()->create();
+
+        $article = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create(['title' => 'Laravel Testing Guide']);
+
+        Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create(['title' => 'PHP Best Practices']);
+
+        $response = $this->getJson('/api/v1/articles?search=Laravel');
+
+        $response->assertStatus(200);
+        expect($response->json('data.articles'))->toHaveCount(1);
+        expect($response->json('data.articles.0.id'))->toBe($article->id);
+    });
+
+    it('can filter articles by author', function () {
+        $author1 = User::factory()->create();
+        $author2 = User::factory()->create();
+
+        $article1 = Article::factory()
+            ->for($author1, 'author')
+            ->for($author1, 'approver')
+            ->published()
+            ->create();
+
+        Article::factory()
+            ->for($author2, 'author')
+            ->for($author2, 'approver')
+            ->published()
+            ->create();
+
+        $response = $this->getJson("/api/v1/articles?created_by={$author1->id}");
+
+        $response->assertStatus(200);
+        expect($response->json('data.articles'))->toHaveCount(1);
+        expect($response->json('data.articles.0.id'))->toBe($article1->id);
+    });
+
+    it('can filter articles by status', function () {
+        $user = User::factory()->create();
+
+        $publishedArticle = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->draft()
+            ->create();
+
+        $response = $this->getJson('/api/v1/articles?status=published');
+
+        $response->assertStatus(200);
+        expect($response->json('data.articles'))->toHaveCount(1);
+        expect($response->json('data.articles.0.id'))->toBe($publishedArticle->id);
+    });
+
+    it('can customize pagination', function () {
+        $user = User::factory()->create();
+        Article::factory()
+            ->count(30)
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $response = $this->getJson('/api/v1/articles?per_page=5&page=2');
+
+        $response->assertStatus(200);
+        expect($response->json('data.articles'))->toHaveCount(5);
+        expect($response->json('data.meta.current_page'))->toBe(2);
+        expect($response->json('data.meta.per_page'))->toBe(5);
+    });
+
+    it('can sort articles', function () {
+        $user = User::factory()->create();
+
+        $article1 = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create(['title' => 'A Article']);
+
+        $article2 = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create(['title' => 'Z Article']);
+
+        $response = $this->getJson('/api/v1/articles?sort_by=title&sort_direction=asc');
+
+        $response->assertStatus(200);
+        expect($response->json('data.articles.0.id'))->toBe($article1->id);
+        expect($response->json('data.articles.1.id'))->toBe($article2->id);
+    });
+
+    it('returns 500 when getting articles fails with exception', function () {
+        // Mock ArticleService to throw an exception
+        $this->mock(\App\Services\ArticleService::class, function ($mock) {
+            $mock->shouldReceive('getArticles')
+                ->andThrow(new \Exception('Database connection failed'));
+        });
+
+        $response = $this->getJson('/api/v1/articles');
+
+        $response->assertStatus(500)
+            ->assertJson([
+                'status' => false,
+                'message' => __('common.something_went_wrong'),
+                'data' => null,
+                'error' => null,
+            ]);
+    });
+});

--- a/tests/Feature/API/V1/Article/ShowArticleControllerTest.php
+++ b/tests/Feature/API/V1/Article/ShowArticleControllerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Article;
+use App\Models\Category;
+use App\Models\Tag;
+use App\Models\User;
+
+describe('API/V1/Article/ShowArticleController', function () {
+    it('can get single article by slug', function () {
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+        $tag = Tag::factory()->create();
+
+        $article = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $article->categories()->attach($category->id);
+        $article->tags()->attach($tag->id);
+
+        $response = $this->getJson("/api/v1/articles/{$article->slug}");
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'data' => [
+                    'id',
+                    'slug',
+                    'title',
+                    'subtitle',
+                    'excerpt',
+                    'content_html',
+                    'content_markdown',
+                    'featured_image',
+                    'status',
+                    'published_at',
+                    'meta_title',
+                    'meta_description',
+                    'created_at',
+                    'updated_at',
+                    'author' => [
+                        'id',
+                        'name',
+                        'email',
+                        'avatar_url',
+                        'bio',
+                    ],
+                    'categories' => [
+                        '*' => [
+                            'id',
+                            'name',
+                            'slug',
+                        ],
+                    ],
+                    'tags' => [
+                        '*' => [
+                            'id',
+                            'name',
+                            'slug',
+                        ],
+                    ],
+                    'authors',
+                    'comments_count',
+                ],
+            ]);
+
+        expect($response->json('data.id'))->toBe($article->id);
+        expect($response->json('data.slug'))->toBe($article->slug);
+    });
+
+    it('returns 404 when article not found by slug', function () {
+        $response = $this->getJson('/api/v1/articles/non-existent-slug');
+
+        $response->assertStatus(404)
+            ->assertJson([
+                'status' => false,
+                'message' => __('common.not_found'),
+                'data' => null,
+                'error' => null,
+            ]);
+    });
+
+    it('returns 500 when showing article fails with exception', function () {
+        // Mock ArticleService to throw an exception
+        $this->mock(\App\Services\ArticleService::class, function ($mock) {
+            $mock->shouldReceive('getArticleBySlug')
+                ->with('test-slug')
+                ->andThrow(new \Exception('Database connection failed'));
+        });
+
+        $response = $this->getJson('/api/v1/articles/test-slug');
+
+        $response->assertStatus(500)
+            ->assertJson([
+                'status' => false,
+                'message' => __('common.something_went_wrong'),
+                'data' => null,
+                'error' => null,
+            ]);
+    });
+});


### PR DESCRIPTION
This pull request introduces a new feature for articles API, including support for retrieving articles with filtering, pagination, and detailed resource representation. It also adds relationships for articles with categories, tags, and authors. The key changes are grouped into the following themes:

### New Controllers for Articles API
* Added `GetArticlesController` to handle paginated retrieval of articles with filtering options, returning a structured JSON response.
* Added `ShowArticleController` to retrieve a specific article by its slug, with detailed error handling for not found and server errors.

### Request Validation and Resource Representation
* Added `GetArticlesRequest` to validate and provide default values for article filtering and pagination parameters.
* Added `ArticleResource` to transform article models into a standardized JSON structure, including relationships like author, categories, tags, and authors.

### Database Relationships for Articles
* Updated the `Article` model to include `categories`, `tags`, and `authors` relationships using `BelongsToMany`.
* Modified the `Category` and `Tag` models to define `articles` as a `BelongsToMany` relationship. [[1]](diffhunk://#diff-db5d75f027f272af0204a0e836200dbb217b74fc70c7dfa5b6c0cf6af09945c9L37-R41) [[2]](diffhunk://#diff-0da5d7e4a39cbc37513390b507e60b12fbcacee014303b4ad807b4ac1db600aaR37-R44)

### Article Service for Business Logic
* Added `ArticleService` to encapsulate the logic for retrieving articles with filters, sorting, and pagination, as well as fetching a single article by slug.

### API Routes and Localization
* Added new routes for listing and showing articles in the `api_v1.php` file.
* Added a localization string for "Resource not found" in `common.php`.