### PR TITLE
feat(categories & tags): added New APIs for categories and tags

### DIFF
--- a/app/Http/Controllers/Api/V1/Category/GetCategoriesController.php
+++ b/app/Http/Controllers/Api/V1/Category/GetCategoriesController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Category;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\Category\CategoryResource;
+use App\Services\ArticleService;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Group('Categories', weight: 2)]
+class GetCategoriesController extends Controller
+{
+    public function __construct(private readonly ArticleService $articleService) {}
+
+    /**
+     * Get All Categories
+     *
+     * @unauthenticated
+     *
+     * @response array{status: true, message: string, data: CategoryResource[]}
+     */
+    public function __invoke(): JsonResponse
+    {
+        try {
+            $categories = $this->articleService->getAllCategories();
+
+            return response()->apiSuccess(
+                CategoryResource::collection($categories),
+                __('common.success')
+            );
+        } catch (\Throwable $e) {
+            return response()->apiError(
+                __('common.error'),
+                Response::HTTP_INTERNAL_SERVER_ERROR,
+                null,
+                $e->getMessage()
+            );
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/Tag/GetTagsController.php
+++ b/app/Http/Controllers/Api/V1/Tag/GetTagsController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Tag;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\Tag\TagResource;
+use App\Services\ArticleService;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Group('Tags', weight: 2)]
+class GetTagsController extends Controller
+{
+    public function __construct(private readonly ArticleService $articleService) {}
+
+    /**
+     * Get All Tags
+     *
+     * @unauthenticated
+     *
+     * @response array{status: true, message: string, data: TagResource[]}
+     */
+    public function __invoke(): JsonResponse
+    {
+        try {
+            $tags = $this->articleService->getAllTags();
+
+            return response()->apiSuccess(
+                TagResource::collection($tags),
+                __('common.success')
+            );
+        } catch (\Throwable $e) {
+            return response()->apiError(
+                __('common.error'),
+                Response::HTTP_INTERNAL_SERVER_ERROR,
+                null,
+                $e->getMessage()
+            );
+        }
+    }
+}

--- a/app/Http/Resources/Api/V1/Category/CategoryResource.php
+++ b/app/Http/Resources/Api/V1/Category/CategoryResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1\Category;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Category
+ */
+class CategoryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/Tag/TagResource.php
+++ b/app/Http/Resources/Api/V1/Tag/TagResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1\Tag;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Tag
+ */
+class TagResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+        ];
+    }
+}

--- a/app/Services/ArticleService.php
+++ b/app/Services/ArticleService.php
@@ -123,4 +123,24 @@ class ArticleService
                 ->where('published_at', '<=', now());
         }
     }
+
+    /**
+     * Get all categories
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, \App\Models\Category>
+     */
+    public function getAllCategories()
+    {
+        return \App\Models\Category::query()->get(['id', 'name', 'slug']);
+    }
+
+    /**
+     * Get all tags
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, \App\Models\Tag>
+     */
+    public function getAllTags()
+    {
+        return \App\Models\Tag::query()->get(['id', 'name', 'slug']);
+    }
 }

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -24,4 +24,10 @@ Route::prefix('v1')->middleware(['throttle:api'])->group(function () {
         Route::get('/', \App\Http\Controllers\Api\V1\Article\GetArticlesController::class)->name('api.v1.articles.index');
         Route::get('/{slug}', \App\Http\Controllers\Api\V1\Article\ShowArticleController::class)->name('api.v1.articles.show');
     });
+
+    // Category Routes (Public)
+    Route::get('categories', \App\Http\Controllers\Api\V1\Category\GetCategoriesController::class)->name('api.v1.categories.index');
+
+    // Tag Routes (Public)
+    Route::get('tags', \App\Http\Controllers\Api\V1\Tag\GetTagsController::class)->name('api.v1.tags.index');
 });

--- a/tests/Feature/API/V1/Category/GetCategoriesControllerTest.php
+++ b/tests/Feature/API/V1/Category/GetCategoriesControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Category;
+
+describe('API/V1/Category/GetCategoriesController', function () {
+    it('can get all categories', function () {
+        Category::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/v1/categories');
+
+        $response->assertStatus(200)
+            ->assertJson(['status' => true])
+            ->assertJson(['message' => __('common.success')])
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'name',
+                        'slug',
+                    ],
+                ],
+            ]);
+
+        expect($response->json('data'))->toHaveCount(3);
+    });
+
+    it('returns error if service throws', function () {
+        $this->mock(\App\Services\ArticleService::class, function ($mock) {
+            $mock->shouldReceive('getAllCategories')
+                ->andThrow(new Exception('fail'));
+        });
+
+        $response = $this->getJson('/api/v1/categories');
+
+        $response->assertStatus(500)
+            ->assertJson(['status' => false])
+            ->assertJson(['message' => __('common.error')])
+            ->assertJsonStructure([
+                'data',
+                'error',
+            ]);
+    });
+});

--- a/tests/Feature/API/V1/Tag/GetTagsControllerTest.php
+++ b/tests/Feature/API/V1/Tag/GetTagsControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Tag;
+
+describe('API/V1/Tag/GetTagsController', function () {
+    it('can get all tags', function () {
+        Tag::factory()->count(4)->create();
+
+        $response = $this->getJson('/api/v1/tags');
+
+        $response->assertStatus(200)
+            ->assertJson(['status' => true])
+            ->assertJson(['message' => __('common.success')])
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'name',
+                        'slug',
+                    ],
+                ],
+            ]);
+
+        expect($response->json('data'))->toHaveCount(4);
+    });
+
+    it('returns error if service throws', function () {
+        $this->mock(\App\Services\ArticleService::class, function ($mock) {
+            $mock->shouldReceive('getAllTags')
+                ->andThrow(new Exception('fail'));
+        });
+
+        $response = $this->getJson('/api/v1/tags');
+
+        $response->assertStatus(500)
+            ->assertJson(['status' => false])
+            ->assertJson(['message' => __('common.error')])
+            ->assertJsonStructure([
+                'data',
+                'error',
+            ]);
+    });
+});


### PR DESCRIPTION
This pull request introduces functionality for retrieving categories and tags via new API endpoints. It includes the addition of controllers, resources, service methods, routes, and feature tests to support these endpoints.

### New API Endpoints for Categories and Tags:

* **Controllers**: Added `GetCategoriesController` and `GetTagsController` to handle requests for retrieving all categories and tags, respectively. Both controllers use the `ArticleService` to fetch data and return JSON responses. (`app/Http/Controllers/Api/V1/Category/GetCategoriesController.php` - [[1]](diffhunk://#diff-665fadf98efa0ea8512abf924a901f5ae0d5eacb5e5c2f3646c2159375dd2e60R1-R44) `app/Http/Controllers/Api/V1/Tag/GetTagsController.php` - [[2]](diffhunk://#diff-1d9695fb6ded3385e49c748e5a06ddc8feca6a9d33799529f7db9908142db81fR1-R44)
* **Resources**: Created `CategoryResource` and `TagResource` to transform category and tag models into API-friendly formats. (`app/Http/Resources/Api/V1/Category/CategoryResource.php` - [[1]](diffhunk://#diff-af01355eb341b780c7375622b07f346380a5dfb1db85e9cceee187bd044c6d02R1-R28) `app/Http/Resources/Api/V1/Tag/TagResource.php` - [[2]](diffhunk://#diff-68363766726f875fb6802ee5ced97065d45c39875c5b553f4e9a46dddab2b658R1-R28)
* **Service Methods**: Added `getAllCategories` and `getAllTags` methods to `ArticleService` to query and return categories and tags. (`app/Services/ArticleService.php` - [app/Services/ArticleService.phpR126-R145](diffhunk://#diff-24f65e74d63383b3832fd5f9fcb86b5f070c4f6b9fd6fa71d9f7edf754b52cccR126-R145))
* **Routes**: Registered new public routes for fetching categories (`/api/v1/categories`) and tags (`/api/v1/tags`). (`routes/api_v1.php` - [routes/api_v1.phpR27-R32](diffhunk://#diff-02d0bc03876b3a09fc06f231c2baef0f0ad622e2c0c7acafeaf9af720cf785f5R27-R32))

### Feature Tests for API Endpoints:

* **Category Tests**: Added tests for `GetCategoriesController` to verify successful retrieval of categories and proper error handling when the service throws an exception. (`tests/Feature/API/V1/Category/GetCategoriesControllerTest.php` - [tests/Feature/API/V1/Category/GetCategoriesControllerTest.phpR1-R45](diffhunk://#diff-edcd35ff71b1902136bfc9190fb3c0fa1da7e8b79f0964f9b03c3ea269296677R1-R45))
* **Tag Tests**: Added tests for `GetTagsController` to ensure the endpoint correctly retrieves tags and handles service exceptions. (`tests/Feature/API/V1/Tag/GetTagsControllerTest.php` - [tests/Feature/API/V1/Tag/GetTagsControllerTest.phpR1-R45](diffhunk://#diff-2fca357dc7902172142b6e1d4311dd2b57a1ef1f291c7507824e30e426c44db5R1-R45))