### PR TITLE
feat(comments): added Get Article comments API

### DIFF
--- a/app/Http/Controllers/Api/V1/Article/GetCommentsController.php
+++ b/app/Http/Controllers/Api/V1/Article/GetCommentsController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Article;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V1\Article\GetCommentsRequest;
+use App\Http\Resources\MetaResource;
+use App\Http\Resources\V1\Comment\CommentResource;
+use App\Models\Article;
+use App\Services\ArticleService;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Group('Comments', weight: 2)]
+class GetCommentsController extends Controller
+{
+    public function __construct(private readonly ArticleService $articleService) {}
+
+    /**
+     * Get Comments List
+     *
+     * Retrieve a paginated list of comments for an article (with 1 child level)
+     *
+     * @unauthenticated
+     *
+     * @response array{status: true, message: string, data: array{comments: CommentResource[], meta: MetaResource}}
+     */
+    public function __invoke(GetCommentsRequest $request, Article $article): JsonResponse
+    {
+        $params = $request->withDefaults();
+
+        try {
+            $parentId = $params['parent_id'] !== null ? (int) $params['parent_id'] : null;
+
+            $commentsDataResponse = CommentResource::collection($this->articleService->getArticleComments(
+                $article->id,
+                $parentId,
+                (int) $params['per_page'],
+                (int) $params['page']
+            ));
+            /** @var array{data: array, meta: array} $commentsData */
+            $commentsData = $commentsDataResponse->response()->getData(true);
+
+            return response()->apiSuccess(
+                [
+                    'comments' => $commentsData['data'],
+                    'meta' => MetaResource::make($commentsData['meta']),
+                ],
+                __('common.success')
+            );
+        } catch (\Throwable $e) {
+            return response()->apiError(
+                __('common.something_went_wrong'),
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+}

--- a/app/Http/Requests/V1/Article/GetCommentsRequest.php
+++ b/app/Http/Requests/V1/Article/GetCommentsRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V1\Article;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetCommentsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'per_page' => 'integer|min:1|max:100',
+            'page' => 'integer|min:1',
+            'parent_id' => 'nullable|integer|exists:comments,id',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function withDefaults(): array
+    {
+        return [
+            'per_page' => $this->input('per_page', 10),
+            'page' => $this->input('page', 1),
+            'parent_id' => $this->input('parent_id'),
+        ];
+    }
+}

--- a/app/Http/Resources/V1/Comment/CommentResource.php
+++ b/app/Http/Resources/V1/Comment/CommentResource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\V1\Comment;
+
+use App\Http\Resources\V1\Auth\UserResource;
+use App\Models\Comment;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Comment
+ */
+class CommentResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'user' => new UserResource($this->whenLoaded('user')),
+            'content' => $this->content,
+            'created_at' => $this->created_at,
+            'replies_count' => $this->replies_count,
+            'replies' => CommentResource::collection($this->whenLoaded('replies_page')),
+        ];
+    }
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $user_id
  * @property string $content
  * @property int|null $parent_comment_id
+ * @property-read int $replies_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Comment>|null $replies_page
  *
  * @mixin \Eloquent
  *
@@ -54,10 +56,12 @@ final class Comment extends Model
     }
 
     /**
-     * @return BelongsTo<Comment,Comment>
+     * Get the replies (child comments) for this comment.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Comment, Comment>
      */
-    public function parent(): BelongsTo
+    public function replies(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->belongsTo(Comment::class, 'parent_comment_id');
+        return $this->hasMany(Comment::class, 'parent_comment_id');
     }
 }

--- a/database/seeders/ArticleCommentSeeder.php
+++ b/database/seeders/ArticleCommentSeeder.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Article;
+use App\Models\Comment;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class ArticleCommentSeeder extends Seeder
+{
+    /**
+     * Run this seeder for API testing purpose only.
+     * NOTE: DON'T RUN THIS IN PRODUCTION, this is for testing purposes only.
+     */
+    public function run(): void
+    {
+        // Create 10 users for comments
+        $users = User::factory(10)->create();
+
+        // Create 20 categories and 30 tags
+        $categories = \App\Models\Category::factory(20)->create();
+        $tags = \App\Models\Tag::factory(30)->create();
+
+        // Create 100 articles
+        $articles = Article::factory(100)->create();
+
+        foreach ($articles as $article) {
+            // Attach 1-3 random categories to each article
+            $article->categories()->attach($categories->random(rand(1, 3))->pluck('id')->toArray());
+            // Attach 2-5 random tags to each article
+            $article->tags()->attach($tags->random(rand(2, 5))->pluck('id')->toArray());
+
+            // Create 10 top-level comments for each article
+            $topComments = [];
+            for ($i = 0; $i < 10; $i++) {
+                $topComments[$i] = Comment::factory()->create([
+                    'article_id' => $article->id,
+                    'user_id' => $users->random()->id,
+                    'parent_comment_id' => null,
+                ]);
+            }
+            // For each top-level comment, create 2 child comments (level 1)
+            foreach ($topComments as $parentComment) {
+                for ($j = 0; $j < 2; $j++) {
+                    $child = Comment::factory()->create([
+                        'article_id' => $article->id,
+                        'user_id' => $users->random()->id,
+                        'parent_comment_id' => $parentComment->id,
+                    ]);
+                    // For each child comment, create 2 more child comments (level 2)
+                    for ($k = 0; $k < 2; $k++) {
+                        Comment::factory()->create([
+                            'article_id' => $article->id,
+                            'user_id' => $users->random()->id,
+                            'parent_comment_id' => $child->id,
+                        ]);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -23,6 +23,7 @@ Route::prefix('v1')->middleware(['throttle:api', 'api.logger'])->group(function 
     Route::prefix('articles')->group(function () {
         Route::get('/', \App\Http\Controllers\Api\V1\Article\GetArticlesController::class)->name('api.v1.articles.index');
         Route::get('/{slug}', \App\Http\Controllers\Api\V1\Article\ShowArticleController::class)->name('api.v1.articles.show');
+        Route::get('/{article:slug}/comments', \App\Http\Controllers\Api\V1\Article\GetCommentsController::class)->name('api.v1.articles.comments.index');
     });
 
     // Category Routes (Public)

--- a/tests/Feature/API/V1/Article/GetCommentsControllerTest.php
+++ b/tests/Feature/API/V1/Article/GetCommentsControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Article;
+use App\Models\Comment;
+use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
+
+describe('API/V1/Article/GetCommentsController', function () {
+    it('returns paginated top-level comments with one level of replies', function () {
+        $user = User::factory()->create();
+        $article = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $topComments = Comment::factory()
+            ->count(5)
+            ->for($article)
+            ->for($user)
+            ->create();
+
+        $topComments->each(fn ($parent) => Comment::factory()
+            ->count(2)
+            ->for($article)
+            ->for($user)
+            ->reply($parent->id)
+            ->create()
+        );
+
+        $response = $this->getJson(route('api.v1.articles.comments.index', [
+            'article' => $article->slug,
+            'per_page' => 3,
+            'page' => 1,
+        ]));
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'data' => [
+                    'comments' => [
+                        '*' => [
+                            'id',
+                            'user' => ['id', 'name', 'email'],
+                            'content',
+                            'created_at',
+                            'replies_count',
+                            'replies' => [
+                                '*' => [
+                                    'id',
+                                    'user' => ['id', 'name', 'email'],
+                                    'content',
+                                    'created_at',
+                                    'replies_count',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'meta' => [
+                        'current_page',
+                        'per_page',
+                        'total',
+                        // Optional keys if MetaResource includes them
+                        // 'last_page', 'from', 'to',
+                    ],
+                ],
+            ]);
+
+        expect($response->json('data.comments'))->toHaveCount(3);
+        expect($response->json('data.meta.total'))->toBe(5);
+    });
+
+    it('returns empty comment list if article has no comments', function () {
+        $user = User::factory()->create();
+        $article = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $response = $this->getJson(route('api.v1.articles.comments.index', [
+            'article' => $article->slug,
+        ]));
+
+        $response->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json->where('status', true)
+                ->where('message', __('common.success'))
+                ->where('data.comments', [])
+                ->where('data.meta.current_page', 1)
+                ->where('data.meta.per_page', 10)
+                ->where('data.meta.total', 0)
+                ->etc()
+            );
+    });
+
+    it('returns 500 on service exception', function () {
+        $user = User::factory()->create();
+        $article = Article::factory()
+            ->for($user, 'author')
+            ->for($user, 'approver')
+            ->published()
+            ->create();
+
+        $this->mock(\App\Services\ArticleService::class, function ($mock) {
+            $mock->shouldReceive('getArticleComments')
+                ->andThrow(new \Exception('Test Exception'));
+        });
+
+        $response = $this->getJson(route('api.v1.articles.comments.index', [
+            'article' => $article->slug,
+        ]));
+
+        $response->assertStatus(500)
+            ->assertJson([
+                'status' => false,
+                'message' => __('common.something_went_wrong'),
+                'data' => null,
+                'error' => null,
+            ]);
+    });
+});


### PR DESCRIPTION
This pull request introduces a new feature to retrieve paginated comments for articles, including one level of child comments. It adds a new controller, request validation, resource classes, and database seeding for testing, as well as updates the model and service layer. Comprehensive test coverage is also included.

### New Feature: Retrieve Paginated Comments

#### Controller and API Endpoint
* Added `GetCommentsController` to handle requests for fetching comments with pagination and child comments. It includes error handling and response formatting.
* Added a new API route to fetch comments for a specific article: `/articles/{article:slug}/comments`.

#### Request Validation and Resource Formatting
* Introduced `GetCommentsRequest` for validating query parameters such as `per_page`, `page`, and `parent_id`.
* Created `CommentResource` to structure the JSON response for comments, including user details, content, and replies.

### Backend Enhancements

#### Model Updates
* Updated the `Comment` model to include `replies_count` and `replies_page` properties, and added a `replies` relationship to fetch child comments. [[1]](diffhunk://#diff-1c72b9439255f694beed193bfb5a5f18d001b6ce3bc63c96a1b491e36da08a83R17-R18) [[2]](diffhunk://#diff-1c72b9439255f694beed193bfb5a5f18d001b6ce3bc63c96a1b491e36da08a83L57-R65)

#### Service Layer
* Added `getArticleComments` method in `ArticleService` to fetch paginated comments with user details, reply counts, and limited child comments.

### Testing and Seeding

#### Database Seeder
* Added `ArticleCommentSeeder` to generate test data for articles, comments, and nested comments.

#### Feature Tests
* Implemented tests for `GetCommentsController` to verify functionality, including successful responses, empty results, and error handling.