### PR TITLE
Fix/add authors relation get articles

### DIFF
--- a/app/Http/Middleware/OptionalSanctumAuthenticate.php
+++ b/app/Http/Middleware/OptionalSanctumAuthenticate.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * Middleware to optionally authenticate a user via Sanctum token.
+ * Sets the user resolver to null if no valid token is present.
+ */
+class OptionalSanctumAuthenticate
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): mixed  $next
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $user = null;
+
+        $token = $request->bearerToken();
+        if (is_string($token) && $token !== '') {
+            $accessToken = PersonalAccessToken::findToken($token);
+            if ($accessToken !== null) {
+                $tokenable = $accessToken->tokenable;
+                // Check for 'access-api' ability
+                if ($tokenable instanceof User && $accessToken->can('access-api')) {
+                    $user = $tokenable;
+                }
+            }
+        }
+
+        $request->setUserResolver(static fn (): ?User => $user);
+
+        return $next($request);
+    }
+}

--- a/app/Services/ArticleService.php
+++ b/app/Services/ArticleService.php
@@ -22,7 +22,12 @@ class ArticleService
     public function getArticles(array $params): LengthAwarePaginator
     {
         $query = Article::query()
-            ->with(['author:id,name,email,avatar_url,bio,twitter,facebook,linkedin,github,website', 'categories:id,name,slug', 'tags:id,name,slug'])
+            ->with([
+                'author:id,name,email,avatar_url,bio,twitter,facebook,linkedin,github,website',
+                'categories:id,name,slug',
+                'tags:id,name,slug',
+                'authors:id,name,email,avatar_url,bio,twitter,facebook,linkedin,github,website',
+            ])
             ->withCount('comments');
 
         // Apply filters

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'ability' => \App\Http\Middleware\CheckTokenAbility::class,
             'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
             'api.logger' => \App\Http\Middleware\ApiLogger::class,
+            'optional.sanctum' => \App\Http\Middleware\OptionalSanctumAuthenticate::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/database/seeders/ArticleCommentSeeder.php
+++ b/database/seeders/ArticleCommentSeeder.php
@@ -28,6 +28,13 @@ class ArticleCommentSeeder extends Seeder
         $articles = Article::factory(100)->create();
 
         foreach ($articles as $article) {
+            // Add 0-3 authors to the authors relation, excluding the main author/created_by
+            $possibleAuthors = $users->where('id', '!=', $article->created_by);
+            $authorCount = rand(0, 3);
+            if ($authorCount > 0 && $possibleAuthors->count() > 0) {
+                $authorIds = $possibleAuthors->random(min($authorCount, $possibleAuthors->count()))->pluck('id')->toArray();
+                $article->authors()->attach($authorIds);
+            }
             // Attach 1-3 random categories to each article
             $article->categories()->attach($categories->random(rand(1, 3))->pluck('id')->toArray());
             // Attach 2-5 random tags to each article

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -19,16 +19,20 @@ Route::prefix('v1')->middleware(['throttle:api', 'api.logger'])->group(function 
         Route::post('/auth/logout', \App\Http\Controllers\Api\V1\Auth\LogoutController::class)->name('api.v1.auth.logout');
     });
 
-    // Article Routes (Public)
-    Route::prefix('articles')->group(function () {
-        Route::get('/', \App\Http\Controllers\Api\V1\Article\GetArticlesController::class)->name('api.v1.articles.index');
-        Route::get('/{slug}', \App\Http\Controllers\Api\V1\Article\ShowArticleController::class)->name('api.v1.articles.show');
-        Route::get('/{article:slug}/comments', \App\Http\Controllers\Api\V1\Article\GetCommentsController::class)->name('api.v1.articles.comments.index');
+    // Public Routes
+    Route::middleware(['optional.sanctum'])->group(function () {
+        // Article Routes
+        Route::prefix('articles')->group(function () {
+            Route::get('/', \App\Http\Controllers\Api\V1\Article\GetArticlesController::class)->name('api.v1.articles.index');
+            Route::get('/{slug}', \App\Http\Controllers\Api\V1\Article\ShowArticleController::class)->name('api.v1.articles.show');
+            Route::get('/{article:slug}/comments', \App\Http\Controllers\Api\V1\Article\GetCommentsController::class)->name('api.v1.articles.comments.index');
+        });
+
+        // Category Routes
+        Route::get('categories', \App\Http\Controllers\Api\V1\Category\GetCategoriesController::class)->name('api.v1.categories.index');
+
+        // Tag Routes
+        Route::get('tags', \App\Http\Controllers\Api\V1\Tag\GetTagsController::class)->name('api.v1.tags.index');
     });
 
-    // Category Routes (Public)
-    Route::get('categories', \App\Http\Controllers\Api\V1\Category\GetCategoriesController::class)->name('api.v1.categories.index');
-
-    // Tag Routes (Public)
-    Route::get('tags', \App\Http\Controllers\Api\V1\Tag\GetTagsController::class)->name('api.v1.tags.index');
 });

--- a/tests/Feature/API/V1/Article/GetArticlesControllerTest.php
+++ b/tests/Feature/API/V1/Article/GetArticlesControllerTest.php
@@ -18,7 +18,7 @@ describe('API/V1/Article/GetArticlesController', function () {
             ->published()
             ->create();
 
-        $response = $this->getJson('/api/v1/articles');
+        $response = $this->getJson(route('api.v1.articles.index'));
 
         $response->assertStatus(200)
             ->assertJsonStructure([
@@ -75,7 +75,7 @@ describe('API/V1/Article/GetArticlesController', function () {
             ->published()
             ->create();
 
-        $response = $this->getJson("/api/v1/articles?category_slug={$category->slug}");
+        $response = $this->getJson(route('api.v1.articles.index', ['category_slug' => $category->slug]));
 
         $response->assertStatus(200);
         expect($response->json('data.articles'))->toHaveCount(1);
@@ -102,7 +102,7 @@ describe('API/V1/Article/GetArticlesController', function () {
             ->published()
             ->create();
 
-        $response = $this->getJson("/api/v1/articles?tag_slug={$tag->slug}");
+        $response = $this->getJson(route('api.v1.articles.index', ['tag_slug' => $tag->slug]));
 
         $response->assertStatus(200);
         expect($response->json('data.articles'))->toHaveCount(1);
@@ -124,7 +124,7 @@ describe('API/V1/Article/GetArticlesController', function () {
             ->published()
             ->create(['title' => 'PHP Best Practices']);
 
-        $response = $this->getJson('/api/v1/articles?search=Laravel');
+        $response = $this->getJson(route('api.v1.articles.index', ['search' => 'Laravel']));
 
         $response->assertStatus(200);
         expect($response->json('data.articles'))->toHaveCount(1);
@@ -147,7 +147,7 @@ describe('API/V1/Article/GetArticlesController', function () {
             ->published()
             ->create();
 
-        $response = $this->getJson("/api/v1/articles?created_by={$author1->id}");
+        $response = $this->getJson(route('api.v1.articles.index', ['created_by' => $author1->id]));
 
         $response->assertStatus(200);
         expect($response->json('data.articles'))->toHaveCount(1);
@@ -169,7 +169,7 @@ describe('API/V1/Article/GetArticlesController', function () {
             ->draft()
             ->create();
 
-        $response = $this->getJson('/api/v1/articles?status=published');
+        $response = $this->getJson(route('api.v1.articles.index', ['status' => 'published']));
 
         $response->assertStatus(200);
         expect($response->json('data.articles'))->toHaveCount(1);
@@ -185,7 +185,7 @@ describe('API/V1/Article/GetArticlesController', function () {
             ->published()
             ->create();
 
-        $response = $this->getJson('/api/v1/articles?per_page=5&page=2');
+        $response = $this->getJson(route('api.v1.articles.index', ['per_page' => 5, 'page' => 2]));
 
         $response->assertStatus(200);
         expect($response->json('data.articles'))->toHaveCount(5);
@@ -208,7 +208,7 @@ describe('API/V1/Article/GetArticlesController', function () {
             ->published()
             ->create(['title' => 'Z Article']);
 
-        $response = $this->getJson('/api/v1/articles?sort_by=title&sort_direction=asc');
+        $response = $this->getJson(route('api.v1.articles.index', ['sort_by' => 'title', 'sort_direction' => 'asc']));
 
         $response->assertStatus(200);
         expect($response->json('data.articles.0.id'))->toBe($article1->id);
@@ -222,7 +222,7 @@ describe('API/V1/Article/GetArticlesController', function () {
                 ->andThrow(new \Exception('Database connection failed'));
         });
 
-        $response = $this->getJson('/api/v1/articles');
+        $response = $this->getJson(route('api.v1.articles.index'));
 
         $response->assertStatus(500)
             ->assertJson([

--- a/tests/Feature/API/V1/Article/ShowArticleControllerTest.php
+++ b/tests/Feature/API/V1/Article/ShowArticleControllerTest.php
@@ -22,7 +22,7 @@ describe('API/V1/Article/ShowArticleController', function () {
         $article->categories()->attach($category->id);
         $article->tags()->attach($tag->id);
 
-        $response = $this->getJson("/api/v1/articles/{$article->slug}");
+        $response = $this->getJson(route('api.v1.articles.show', ['slug' => $article->slug]));
 
         $response->assertStatus(200)
             ->assertJsonStructure([
@@ -46,7 +46,6 @@ describe('API/V1/Article/ShowArticleController', function () {
                     'author' => [
                         'id',
                         'name',
-                        'email',
                         'avatar_url',
                         'bio',
                     ],
@@ -76,6 +75,7 @@ describe('API/V1/Article/ShowArticleController', function () {
     it('returns 404 when article not found by slug', function () {
         $response = $this->getJson('/api/v1/articles/non-existent-slug');
 
+        $response = $this->getJson(route('api.v1.articles.show', ['slug' => 'non-existent-slug']));
         $response->assertStatus(404)
             ->assertJson([
                 'status' => false,
@@ -93,7 +93,7 @@ describe('API/V1/Article/ShowArticleController', function () {
                 ->andThrow(new \Exception('Database connection failed'));
         });
 
-        $response = $this->getJson('/api/v1/articles/test-slug');
+        $response = $this->getJson(route('api.v1.articles.show', ['slug' => 'test-slug']));
 
         $response->assertStatus(500)
             ->assertJson([

--- a/tests/Feature/Middleware/ApiLoggerTest.php
+++ b/tests/Feature/Middleware/ApiLoggerTest.php
@@ -2,125 +2,111 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Middleware;
-
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
-use Tests\TestCase;
 
-class ApiLoggerTest extends TestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
-        // Ensure logging is enabled for tests
-        Config::set('api-logger.enabled', true);
-        // Create a test route using the middleware
-        Route::middleware('api.logger')->post('/test-api-logger', function () {
-            return response()->json(['success' => true, 'token' => 'shouldbemasked']);
-        });
-    }
+beforeEach(function () {
+    // Ensure logging is enabled for tests
+    Config::set('api-logger.enabled', true);
+    // Create a test route using the middleware
+    Route::middleware('api.logger')->post('/test-api-logger', function () {
+        return response()->json(['success' => true, 'token' => 'shouldbemasked']);
+    });
+});
 
-    public function test_logs_request_and_response_with_masking()
-    {
-        Log::spy();
-        $payload = [
-            'username' => 'testuser',
-            'password' => 'supersecret',
-        ];
-        $headers = [
-            'Authorization' => 'Bearer sometoken',
-            'X-Request-Id' => 'test-request-id-123',
-        ];
+test('logs request and response with masking', function () {
+    Log::spy();
+    $payload = [
+        'username' => 'testuser',
+        'password' => 'supersecret',
+    ];
+    $headers = [
+        'Authorization' => 'Bearer sometoken',
+        'X-Request-Id' => 'test-request-id-123',
+    ];
 
-        $response = $this->postJson('/test-api-logger', $payload, $headers);
-        $response->assertOk();
-        $response->assertJson(['success' => true]);
+    $response = $this->postJson('/test-api-logger', $payload, $headers);
+    $response->assertOk();
+    $response->assertJson(['success' => true]);
 
-        Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($headers) {
-            return $message === 'API Request'
-                && $context['request_id'] === $headers['X-Request-Id']
-                && $context['body']['password'] === '***MASKED***'
-                && $context['headers']['authorization'] === '***MASKED***'
-                && $context['response_body']['token'] === '***MASKED***';
-        })->once();
-    }
+    Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($headers) {
+        return $message === 'API Request'
+            && $context['request_id'] === $headers['X-Request-Id']
+            && $context['body']['password'] === '***MASKED***'
+            && $context['headers']['authorization'] === '***MASKED***'
+            && $context['response_body']['token'] === '***MASKED***';
+    })->once();
+});
 
-    public function test_does_not_log_when_disabled()
-    {
-        Config::set('api-logger.enabled', false);
-        Log::spy();
-        $response = $this->postJson('/test-api-logger', []);
-        $response->assertOk();
-        Log::shouldNotHaveReceived('info');
-    }
+test('does not log when disabled', function () {
+    Config::set('api-logger.enabled', false);
+    Log::spy();
+    $response = $this->postJson('/test-api-logger', []);
+    $response->assertOk();
+    Log::shouldNotHaveReceived('info');
+});
 
-    public function test_logs_with_custom_masked_headers_and_body_keys()
-    {
-        Config::set('api-logger.masked_headers', ['authorization', 'x-custom-header']);
-        Config::set('api-logger.masked_body_keys', ['password', 'secret']);
-        Log::spy();
-        $payload = [
-            'username' => 'testuser',
-            'password' => 'supersecret',
-            'secret' => 'topsecret',
-        ];
-        $headers = [
-            'Authorization' => 'Bearer sometoken',
-            'X-Custom-Header' => 'customvalue',
-            'X-Request-Id' => 'custom-id-456',
-        ];
-        $response = $this->postJson('/test-api-logger', $payload, $headers);
-        $response->assertOk();
-        Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
-            return $context['headers']['authorization'] === '***MASKED***'
-                && $context['headers']['x-custom-header'] === '***MASKED***'
-                && $context['body']['password'] === '***MASKED***'
-                && $context['body']['secret'] === '***MASKED***';
-        })->once();
-    }
+test('logs with custom masked headers and body keys', function () {
+    Config::set('api-logger.masked_headers', ['authorization', 'x-custom-header']);
+    Config::set('api-logger.masked_body_keys', ['password', 'secret']);
+    Log::spy();
+    $payload = [
+        'username' => 'testuser',
+        'password' => 'supersecret',
+        'secret' => 'topsecret',
+    ];
+    $headers = [
+        'Authorization' => 'Bearer sometoken',
+        'X-Custom-Header' => 'customvalue',
+        'X-Request-Id' => 'custom-id-456',
+    ];
+    $response = $this->postJson('/test-api-logger', $payload, $headers);
+    $response->assertOk();
+    Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
+        return $context['headers']['authorization'] === '***MASKED***'
+            && $context['headers']['x-custom-header'] === '***MASKED***'
+            && $context['body']['password'] === '***MASKED***'
+            && $context['body']['secret'] === '***MASKED***';
+    })->once();
+});
 
-    public function test_logs_all_context_fields()
-    {
-        Log::spy();
-        $payload = ['username' => 'testuser'];
-        $headers = [
-            'X-Request-Id' => 'all-fields-id',
-        ];
-        $response = $this->postJson('/test-api-logger', $payload, $headers);
-        $response->assertOk();
-        Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($headers) {
-            return $context['request_id'] === $headers['X-Request-Id']
-                && isset($context['ip'])
-                && $context['method'] === 'POST'
-                && str_contains($context['uri'], '/test-api-logger')
-                && $context['response_status'] === 200
-                && is_numeric($context['duration_ms']);
-        })->once();
-    }
+test('logs all context fields', function () {
+    Log::spy();
+    $payload = ['username' => 'testuser'];
+    $headers = [
+        'X-Request-Id' => 'all-fields-id',
+    ];
+    $response = $this->postJson('/test-api-logger', $payload, $headers);
+    $response->assertOk();
+    Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($headers) {
+        return $context['request_id'] === $headers['X-Request-Id']
+            && isset($context['ip'])
+            && $context['method'] === 'POST'
+            && str_contains($context['uri'], '/test-api-logger')
+            && $context['response_status'] === 200
+            && is_numeric($context['duration_ms']);
+    })->once();
+});
 
-    public function test_logs_non_json_response()
-    {
-        Route::middleware('api.logger')->get('/test-non-json', function () {
-            return 'plain text response';
-        });
-        Log::spy();
-        $response = $this->get('/test-non-json');
-        $response->assertOk();
-        $response->assertSee('plain text response');
-        Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
-            return $context['response_body'] === 'plain text response';
-        })->once();
-    }
+test('logs non json response', function () {
+    Route::middleware('api.logger')->get('/test-non-json', function () {
+        return 'plain text response';
+    });
+    Log::spy();
+    $response = $this->get('/test-non-json');
+    $response->assertOk();
+    $response->assertSee('plain text response');
+    Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
+        return $context['response_body'] === 'plain text response';
+    })->once();
+});
 
-    public function test_logs_with_empty_headers_and_body()
-    {
-        Log::spy();
-        $response = $this->postJson('/test-api-logger', [], []);
-        $response->assertOk();
-        Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
-            return is_array($context['headers']) && is_array($context['body']);
-        })->once();
-    }
-}
+test('logs with empty headers and body', function () {
+    Log::spy();
+    $response = $this->postJson('/test-api-logger', [], []);
+    $response->assertOk();
+    Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
+        return is_array($context['headers']) && is_array($context['body']);
+    })->once();
+});

--- a/tests/Feature/Middleware/OptionalSanctumAuthenticateTest.php
+++ b/tests/Feature/Middleware/OptionalSanctumAuthenticateTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function () {
+    // Register a test route using the middleware
+    Route::middleware('optional.sanctum')->get('/test-optional-auth', function () {
+        return response()->json([
+            'user_id' => optional(request()->user())->id,
+        ]);
+    });
+});
+
+test('authenticates user with valid token', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('test-token', ['access-api'])->plainTextToken;
+
+    $response = $this->withHeader('Authorization', 'Bearer '.$token)
+        ->getJson('/test-optional-auth');
+
+    $response->assertOk();
+    $response->assertJson(['user_id' => $user->id]);
+});
+
+test('does not authenticate user without access_api ability', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('test-token', ['other-ability'])->plainTextToken;
+
+    $response = $this->withHeader('Authorization', 'Bearer '.$token)
+        ->getJson('/test-optional-auth');
+
+    $response->assertOk();
+    $response->assertJson(['user_id' => null]);
+});
+
+test('sets user resolver to null if no token', function () {
+    $response = $this->getJson('/test-optional-auth');
+    $response->assertOk();
+    $response->assertJson(['user_id' => null]);
+});
+
+test('sets user resolver to null if token invalid', function () {
+    $response = $this->withHeader('Authorization', 'Bearer invalidtoken')
+        ->getJson('/test-optional-auth');
+    $response->assertOk();
+    $response->assertJson(['user_id' => null]);
+});
+
+test('allows request to proceed without authentication', function () {
+    $response = $this->getJson('/test-optional-auth');
+    $response->assertOk();
+    $response->assertJson(['user_id' => null]);
+});


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across middleware, API resources, route handling, and test cases. The most significant updates include the addition of a new middleware for optional Sanctum authentication, improvements to the `ArticleResource` for conditional email visibility, and refactoring of test cases for improved readability and maintainability.

### Middleware and Routing Enhancements:
* Added `OptionalSanctumAuthenticate` middleware to allow optional user authentication via Sanctum tokens. This middleware resolves the user to `null` if no valid token is provided (`app/Http/Middleware/OptionalSanctumAuthenticate.php`).
* Registered the new middleware under the alias `optional.sanctum` in the application bootstrap file (`bootstrap/app.php`).
* Updated API routes to use the `optional.sanctum` middleware for public routes, enabling optional authentication (`routes/api_v1.php`).

### API Resource Improvements:
* Modified `ArticleResource` to conditionally display the `email` field of authors and co-authors only to users with the `ADMINISTRATOR` role (`app/Http/Resources/V1/Article/ArticleResource.php`). [[1]](diffhunk://#diff-6747a670bd26f118eb1d2bfad90d5415fa42e88db225fa87936f8e9a21b9f458L39-R45) [[2]](diffhunk://#diff-6747a670bd26f118eb1d2bfad90d5415fa42e88db225fa87936f8e9a21b9f458L80-L99)

### Database and Seeder Updates:
* Updated the `ArticleService` to include the `authors` relationship in the `getArticles` query (`app/Services/ArticleService.php`).
* Enhanced the `ArticleCommentSeeder` to assign 0–3 co-authors to articles, excluding the main author (`database/seeders/ArticleCommentSeeder.php`).

### Test Refactoring:
* Refactored `ApiLoggerTest` to use Pest-style syntax, improving readability and reducing boilerplate code (`tests/Feature/Middleware/ApiLoggerTest.php`). [[1]](diffhunk://#diff-5e0db1bb1ce171815447996b0b6ba8a3a3ee3850a375ee5f1fc6b3fec6a397a0L5-R18) [[2]](diffhunk://#diff-5e0db1bb1ce171815447996b0b6ba8a3a3ee3850a375ee5f1fc6b3fec6a397a0L48-R50) [[3]](diffhunk://#diff-5e0db1bb1ce171815447996b0b6ba8a3a3ee3850a375ee5f1fc6b3fec6a397a0L82-R74) [[4]](diffhunk://#diff-5e0db1bb1ce171815447996b0b6ba8a3a3ee3850a375ee5f1fc6b3fec6a397a0L101-R92) [[5]](diffhunk://#diff-5e0db1bb1ce171815447996b0b6ba8a3a3ee3850a375ee5f1fc6b3fec6a397a0L115-R112)
* Updated test cases for `GetArticlesController` and `ShowArticleController` to use named routes instead of hardcoded URLs, ensuring consistency and maintainability (`tests/Feature/API/V1/Article/GetArticlesControllerTest.php`, `tests/Feature/API/V1/Article/ShowArticleControllerTest.php`). [[1]](diffhunk://#diff-d2ba2c6a7bf77793ce80610c997fa8a21b6cc86fe9c6fea13a7afa869a47a815L21-R21) [[2]](diffhunk://#diff-d2ba2c6a7bf77793ce80610c997fa8a21b6cc86fe9c6fea13a7afa869a47a815L78-R78) [[3]](diffhunk://#diff-d2ba2c6a7bf77793ce80610c997fa8a21b6cc86fe9c6fea13a7afa869a47a815L105-R105) [[4]](diffhunk://#diff-d2ba2c6a7bf77793ce80610c997fa8a21b6cc86fe9c6fea13a7afa869a47a815L127-R127) [[5]](diffhunk://#diff-d2ba2c6a7bf77793ce80610c997fa8a21b6cc86fe9c6fea13a7afa869a47a815L150-R150) [[6]](diffhunk://#diff-d2ba2c6a7bf77793ce80610c997fa8a21b6cc86fe9c6fea13a7afa869a47a815L172-R172) [[7]](diffhunk://#diff-d2ba2c6a7bf77793ce80610c997fa8a21b6cc86fe9c6fea13a7afa869a47a815L188-R188) [[8]](diffhunk://#diff-d2ba2c6a7bf77793ce80610c997fa8a21b6cc86fe9c6fea13a7afa869a47a815L211-R211) [[9]](diffhunk://#diff-d2ba2c6a7bf77793ce80610c997fa8a21b6cc86fe9c6fea13a7afa869a47a815L225-R225) [[10]](diffhunk://#diff-ce9bca8304e99569afdb068b923c62fd9a11dba36c5be9acb7c8e6366c9b88f4L25-R25) [[11]](diffhunk://#diff-ce9bca8304e99569afdb068b923c62fd9a11dba36c5be9acb7c8e6366c9b88f4L49) [[12]](diffhunk://#diff-ce9bca8304e99569afdb068b923c62fd9a11dba36c5be9acb7c8e6366c9b88f4R78) [[13]](diffhunk://#diff-ce9bca8304e99569afdb068b923c62fd9a11dba36c5be9acb7c8e6366c9b88f4L96-R96)