### PR TITLE
perf: roles permissions cache

### DIFF
--- a/app/Console/Commands/ClearRolePermissionCache.php
+++ b/app/Console/Commands/ClearRolePermissionCache.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Constants\CacheKeys;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+final class ClearRolePermissionCache extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cache:clear-roles-permissions {--user-id= : Clear cache for specific user} {--all : Clear all user caches by incrementing version}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear role and permission caches';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $userId = $this->option('user-id');
+        $clearAll = $this->option('all');
+
+        if ($userId) {
+            $user = User::find($userId);
+            if (! $user) {
+                $this->error("User with ID {$userId} not found.");
+
+                return 1;
+            }
+
+            $user->clearCache();
+            $this->info("Cache cleared for user: {$user->name} (ID: {$userId})");
+        } elseif ($clearAll) {
+            $this->clearAllUserCaches();
+            $this->info('All user caches cleared by incrementing cache version.');
+        } else {
+            $this->clearGlobalCaches();
+            $this->info('Global role and permission caches cleared successfully.');
+        }
+
+        return 0;
+    }
+
+    /**
+     * Clear all user caches by incrementing version
+     */
+    private function clearAllUserCaches(): void
+    {
+        /** @var int $currentVersion */
+        $currentVersion = Cache::get('user_cache_version', 1);
+        $newVersion = $currentVersion + 1;
+
+        Cache::put('user_cache_version', $newVersion, CacheKeys::CACHE_TTL);
+
+        $this->info("Cache version incremented from {$currentVersion} to {$newVersion}");
+        $this->info('All user caches are now invalidated.');
+    }
+
+    /**
+     * Clear global role and permission caches
+     */
+    private function clearGlobalCaches(): void
+    {
+        // Clear global caches
+        Cache::forget(CacheKeys::ALL_ROLES_CACHE_KEY);
+        Cache::forget(CacheKeys::ALL_PERMISSIONS_CACHE_KEY);
+
+        $this->info('Global caches cleared successfully.');
+    }
+}

--- a/app/Constants/CacheKeys.php
+++ b/app/Constants/CacheKeys.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Constants;
+
+final class CacheKeys
+{
+    public const CACHE_TTL = 3600; // 1 hour
+
+    // User-specific cache keys
+    public const USER_ROLES_CACHE_KEY = 'user_roles_';
+
+    public const USER_PERMISSIONS_CACHE_KEY = 'user_permissions_';
+
+    // Global cache keys
+    public const ALL_ROLES_CACHE_KEY = 'all_roles_with_permissions';
+
+    public const ALL_PERMISSIONS_CACHE_KEY = 'all_permissions';
+
+    /**
+     * Get user roles cache key
+     */
+    public static function userRoles(int $userId): string
+    {
+        return self::USER_ROLES_CACHE_KEY.$userId;
+    }
+
+    /**
+     * Get user permissions cache key
+     */
+    public static function userPermissions(int $userId): string
+    {
+        return self::USER_PERMISSIONS_CACHE_KEY.$userId;
+    }
+}

--- a/app/Http/Resources/V1/Auth/UserResource.php
+++ b/app/Http/Resources/V1/Auth/UserResource.php
@@ -32,6 +32,9 @@ class UserResource extends JsonResource
             'website' => $this->resource->website,
             'roles' => $this->whenLoaded('roles', function () {
                 return $this->resource->roles->pluck('slug');
+            }, function () {
+                // Fallback to cached roles if not loaded
+                return $this->resource->getCachedRoles();
             }),
             'permissions' => $this->whenLoaded('roles', function () {
                 $permissionSlugs = [];
@@ -47,6 +50,9 @@ class UserResource extends JsonResource
                 }
 
                 return array_values(array_unique($permissionSlugs));
+            }, function () {
+                // Fallback to cached permissions if not loaded
+                return $this->resource->getCachedPermissions();
             }),
             $this->mergeWhen(
                 array_key_exists('access_token', $this->resource->getAttributes()),

--- a/app/Traits/HasCachedRolesAndPermissions.php
+++ b/app/Traits/HasCachedRolesAndPermissions.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+use App\Constants\CacheKeys;
+use Illuminate\Support\Facades\Cache;
+
+trait HasCachedRolesAndPermissions
+{
+    /**
+     * Get cached permissions for the user
+     *
+     * @return array<int, string>
+     */
+    public function getCachedPermissions(): array
+    {
+        $cacheVersion = $this->getCacheVersion();
+        $cacheKey = CacheKeys::userPermissions($this->id).'_v'.$cacheVersion;
+
+        /** @var array<int, string> $result */
+        $result = Cache::remember($cacheKey, CacheKeys::CACHE_TTL, function () {
+            $this->load('roles.permissions');
+
+            return $this->extractPermissionsFromRoles();
+        });
+
+        return $result;
+    }
+
+    /**
+     * Get cached roles for the user
+     *
+     * @return array<int, string>
+     */
+    public function getCachedRoles(): array
+    {
+        $cacheVersion = $this->getCacheVersion();
+        $cacheKey = CacheKeys::userRoles($this->id).'_v'.$cacheVersion;
+
+        /** @var array<int, string> $result */
+        $result = Cache::remember($cacheKey, CacheKeys::CACHE_TTL, function () {
+            return $this->roles->pluck('name')->toArray();
+        });
+
+        return $result;
+    }
+
+    /**
+     * Check if the user has a given permission using cache
+     */
+    public function hasCachedPermission(string $permission): bool
+    {
+        $permissions = $this->getCachedPermissions();
+
+        return in_array($permission, $permissions, true);
+    }
+
+    /**
+     * Check if the user has any of the given permissions using cache
+     *
+     * @param  array<int, string>  $permissions
+     */
+    public function hasAnyCachedPermission(array $permissions): bool
+    {
+        $userPermissions = $this->getCachedPermissions();
+
+        return ! empty(array_intersect($permissions, $userPermissions));
+    }
+
+    /**
+     * Check if the user has all of the given permissions using cache
+     *
+     * @param  array<int, string>  $permissions
+     */
+    public function hasAllCachedPermissions(array $permissions): bool
+    {
+        $userPermissions = $this->getCachedPermissions();
+
+        return empty(array_diff($permissions, $userPermissions));
+    }
+
+    /**
+     * Check if the user has a given role using cache
+     */
+    public function hasCachedRole(string $role): bool
+    {
+        $roles = $this->getCachedRoles();
+
+        return in_array($role, $roles, true);
+    }
+
+    /**
+     * Check if the user has any of the given roles using cache
+     *
+     * @param  array<int, string>  $roles
+     */
+    public function hasAnyCachedRole(array $roles): bool
+    {
+        $userRoles = $this->getCachedRoles();
+
+        return ! empty(array_intersect($roles, $userRoles));
+    }
+
+    /**
+     * Check if the user has all of the given roles using cache
+     *
+     * @param  array<int, string>  $roles
+     */
+    public function hasAllCachedRoles(array $roles): bool
+    {
+        $userRoles = $this->getCachedRoles();
+
+        return empty(array_diff($roles, $userRoles));
+    }
+
+    /**
+     * Clear user's cached permissions and roles
+     */
+    public function clearCache(): void
+    {
+        // Clear individual user cache (for specific user updates)
+        $cacheVersion = $this->getCacheVersion();
+        Cache::forget(CacheKeys::userPermissions($this->id).'_v'.$cacheVersion);
+        Cache::forget(CacheKeys::userRoles($this->id).'_v'.$cacheVersion);
+    }
+
+    /**
+     * Refresh user's cached permissions and roles
+     */
+    public function refreshCache(): void
+    {
+        $this->clearCache();
+        $this->getCachedPermissions();
+        $this->getCachedRoles();
+    }
+
+    /**
+     * Get current cache version
+     */
+    private function getCacheVersion(): int
+    {
+        /** @var int $result */
+        $result = Cache::get('user_cache_version', 1);
+
+        return $result;
+    }
+
+    /**
+     * Extract permissions from user's roles
+     *
+     * @return array<int, string>
+     */
+    private function extractPermissionsFromRoles(): array
+    {
+        $permissions = [];
+
+        foreach ($this->roles as $role) {
+            foreach ($role->permissions as $permission) {
+                $permissions[] = $permission->name;
+            }
+        }
+
+        return array_unique($permissions);
+    }
+}

--- a/database/migrations/2025_07_04_205615_create_role_user_table.php
+++ b/database/migrations/2025_07_04_205615_create_role_user_table.php
@@ -15,6 +15,10 @@ return new class extends Migration
             $table->foreignId('role_id')->constrained('roles')->onDelete('cascade');
             $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
             $table->primary(['role_id', 'user_id']);
+
+            // Add indexes for better query performance
+            $table->index('user_id');
+            $table->index('role_id');
         });
     }
 

--- a/database/migrations/2025_07_04_205616_create_permission_role_table.php
+++ b/database/migrations/2025_07_04_205616_create_permission_role_table.php
@@ -15,6 +15,10 @@ return new class extends Migration
             $table->foreignId('permission_id')->constrained('permissions')->onDelete('cascade');
             $table->foreignId('role_id')->constrained('roles')->onDelete('cascade');
             $table->primary(['permission_id', 'role_id']);
+
+            // Add indexes for better query performance
+            $table->index('role_id');
+            $table->index('permission_id');
         });
     }
 

--- a/tests/Feature/Console/ClearRolePermissionCacheTest.php
+++ b/tests/Feature/Console/ClearRolePermissionCacheTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Constants\CacheKeys;
+use App\Enums\UserRole;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+describe('ClearRolePermissionCache Command', function () {
+    beforeEach(function () {
+        // Clear all caches before each test
+        Cache::flush();
+    });
+
+    it('clears cache for specific user', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Cache some data
+        $user->getCachedRoles();
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+
+        // Act
+        $this->artisan('cache:clear-roles-permissions', ['--user-id' => $user->id])
+            ->expectsOutput("Cache cleared for user: {$user->name} (ID: {$user->id})")
+            ->assertExitCode(0);
+
+        // Assert
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeFalse();
+    });
+
+    it('handles non-existent user gracefully', function () {
+        // Act
+        $this->artisan('cache:clear-roles-permissions', ['--user-id' => 99999])
+            ->expectsOutput('User with ID 99999 not found.')
+            ->assertExitCode(1);
+    });
+
+    it('clears all user caches by incrementing version', function () {
+        // Arrange
+        $users = User::factory()->count(3)->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+
+        foreach ($users as $user) {
+            $user->roles()->attach($role->id);
+            $user->getCachedRoles();
+            expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+        }
+
+        // Act
+        $this->artisan('cache:clear-roles-permissions', ['--all' => true])
+            ->expectsOutput('All user caches cleared by incrementing cache version.')
+            ->assertExitCode(0);
+
+        // Assert - New cache should be created with version 2
+        $users[0]->getCachedRoles();
+        expect(Cache::has('user_roles_'.$users[0]->id.'_v2'))->toBeTrue();
+    });
+
+    it('clears global caches when no options provided', function () {
+        // Arrange - Set up some global caches
+        Cache::put(CacheKeys::ALL_ROLES_CACHE_KEY, ['test'], CacheKeys::CACHE_TTL);
+        Cache::put(CacheKeys::ALL_PERMISSIONS_CACHE_KEY, ['test'], CacheKeys::CACHE_TTL);
+
+        expect(Cache::has(CacheKeys::ALL_ROLES_CACHE_KEY))->toBeTrue();
+        expect(Cache::has(CacheKeys::ALL_PERMISSIONS_CACHE_KEY))->toBeTrue();
+
+        // Act
+        $this->artisan('cache:clear-roles-permissions')
+            ->expectsOutput('Global role and permission caches cleared successfully.')
+            ->assertExitCode(0);
+
+        // Assert
+        expect(Cache::has(CacheKeys::ALL_ROLES_CACHE_KEY))->toBeFalse();
+        expect(Cache::has(CacheKeys::ALL_PERMISSIONS_CACHE_KEY))->toBeFalse();
+    });
+
+    it('increments cache version correctly', function () {
+        // Arrange
+        $initialVersion = Cache::get('user_cache_version', 1);
+        expect($initialVersion)->toBe(1);
+
+        // Act
+        $this->artisan('cache:clear-roles-permissions', ['--all' => true])
+            ->expectsOutput('Cache version incremented from 1 to 2')
+            ->expectsOutput('All user caches are now invalidated.')
+            ->assertExitCode(0);
+
+        // Assert
+        $newVersion = Cache::get('user_cache_version');
+        expect($newVersion)->toBe(2);
+    });
+
+    it('handles multiple version increments', function () {
+        // Arrange
+        Cache::put('user_cache_version', 5, CacheKeys::CACHE_TTL);
+
+        // Act
+        $this->artisan('cache:clear-roles-permissions', ['--all' => true])
+            ->expectsOutput('Cache version incremented from 5 to 6')
+            ->expectsOutput('All user caches are now invalidated.')
+            ->assertExitCode(0);
+
+        // Assert
+        $newVersion = Cache::get('user_cache_version');
+        expect($newVersion)->toBe(6);
+    });
+});

--- a/tests/Feature/Models/UserCachingTest.php
+++ b/tests/Feature/Models/UserCachingTest.php
@@ -1,0 +1,400 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Constants\CacheKeys;
+use App\Enums\UserRole;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+describe('User Caching', function () {
+    beforeEach(function () {
+        // Clear all caches before each test
+        Cache::flush();
+    });
+
+    it('caches user roles correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Act
+        $cachedRoles = $user->getCachedRoles();
+
+        // Assert
+        expect($cachedRoles)->toBe([UserRole::AUTHOR->value]);
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+    });
+
+    it('caches user permissions correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $permission = Permission::where('name', 'publish_posts')->first();
+
+        // Check if permission is already attached to avoid duplicates
+        if (! $role->permissions()->where('permission_id', $permission->id)->exists()) {
+            $role->permissions()->attach($permission->id);
+        }
+        $user->roles()->attach($role->id);
+
+        // Act
+        $cachedPermissions = $user->getCachedPermissions();
+
+        // Assert
+        expect($cachedPermissions)->toContain('publish_posts');
+        expect(Cache::has('user_permissions_'.$user->id.'_v1'))->toBeTrue();
+    });
+
+    it('uses cached data for permission checks', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $permission = Permission::where('name', 'publish_posts')->first();
+
+        // Check if permission is already attached to avoid duplicates
+        if (! $role->permissions()->where('permission_id', $permission->id)->exists()) {
+            $role->permissions()->attach($permission->id);
+        }
+        $user->roles()->attach($role->id);
+
+        // Act - First call should cache
+        $hasPermission = $user->hasCachedPermission('publish_posts');
+
+        // Assert
+        expect($hasPermission)->toBeTrue();
+        expect(Cache::has('user_permissions_'.$user->id.'_v1'))->toBeTrue();
+    });
+
+    it('clears cache when user is updated', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Cache some data
+        $user->getCachedRoles();
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+
+        // Act
+        $user->update(['name' => 'Updated Name']);
+
+        // Assert - Cache should be cleared
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeFalse();
+    });
+
+    it('invalidates all caches when role permissions change', function () {
+        // Arrange
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+
+        $user1->roles()->attach($role->id);
+        $user2->roles()->attach($role->id);
+
+        // Cache data for both users
+        $user1->getCachedRoles();
+        $user2->getCachedRoles();
+
+        expect(Cache::has('user_roles_'.$user1->id.'_v1'))->toBeTrue();
+        expect(Cache::has('user_roles_'.$user2->id.'_v1'))->toBeTrue();
+
+        // Act - Update role (this should increment cache version)
+        $role->update(['name' => 'Updated Author']);
+
+        // Assert - New cache should be created with new version
+        $user1->getCachedRoles();
+        expect(Cache::has('user_roles_'.$user1->id.'_v2'))->toBeTrue();
+    });
+
+    it('handles multiple permissions correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $permission1 = Permission::where('name', 'publish_posts')->first();
+        $permission2 = Permission::where('name', 'edit_posts')->first();
+
+        // Check if permissions are already attached to avoid duplicates
+        if (! $role->permissions()->where('permission_id', $permission1->id)->exists()) {
+            $role->permissions()->attach($permission1->id);
+        }
+        if (! $role->permissions()->where('permission_id', $permission2->id)->exists()) {
+            $role->permissions()->attach($permission2->id);
+        }
+        $user->roles()->attach($role->id);
+
+        // Act
+        $hasAny = $user->hasAnyCachedPermission(['publish_posts', 'delete_posts']);
+        $hasAll = $user->hasAllCachedPermissions(['publish_posts', 'edit_posts']);
+
+        // Assert
+        expect($hasAny)->toBeTrue(); // Has publish_posts
+        expect($hasAll)->toBeTrue(); // Has both permissions
+    });
+
+    it('handles multiple roles correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $authorRole = Role::where('name', UserRole::AUTHOR->value)->first();
+        $editorRole = Role::where('name', UserRole::EDITOR->value)->first();
+        $user->roles()->attach([$authorRole->id, $editorRole->id]);
+
+        // Act
+        $hasAny = $user->hasAnyCachedRole([UserRole::AUTHOR->value, UserRole::ADMINISTRATOR->value]);
+        $hasAll = $user->hasAllCachedRoles([UserRole::AUTHOR->value, UserRole::EDITOR->value]);
+
+        // Assert
+        expect($hasAny)->toBeTrue(); // Has author role
+        expect($hasAll)->toBeTrue(); // Has both roles
+    });
+
+    it('handles users with no roles', function () {
+        // Arrange
+        $user = User::factory()->create();
+
+        // Act
+        $cachedRoles = $user->getCachedRoles();
+        $cachedPermissions = $user->getCachedPermissions();
+
+        // Assert
+        expect($cachedRoles)->toBe([]);
+        expect($cachedPermissions)->toBe([]);
+        expect($user->hasCachedRole('admin'))->toBeFalse();
+        expect($user->hasCachedPermission('edit_posts'))->toBeFalse();
+    });
+
+    it('handles users with no permissions', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::SUBSCRIBER->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Act
+        $cachedPermissions = $user->getCachedPermissions();
+
+        // Assert - Subscriber role should have some permissions from seeder
+        expect($cachedPermissions)->not->toBeEmpty();
+        expect($user->hasCachedPermission('edit_posts'))->toBeFalse();
+    });
+
+    it('refreshes cache correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Cache initial data
+        $user->getCachedRoles();
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+
+        // Act
+        $user->refreshCache();
+
+        // Assert - Cache should be rebuilt
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+        expect($user->getCachedRoles())->toBe([UserRole::AUTHOR->value]);
+    });
+
+    it('handles cache versioning correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Cache with version 1
+        $user->getCachedRoles();
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+
+        // Act - Increment cache version
+        Cache::put('user_cache_version', 2, CacheKeys::CACHE_TTL);
+
+        // Assert - New cache should be created with version 2
+        $user->getCachedRoles(); // This should create v2 cache
+        expect(Cache::has('user_roles_'.$user->id.'_v2'))->toBeTrue();
+    });
+
+    it('handles permission changes through role updates', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $permission = Permission::where('name', 'publish_posts')->first();
+
+        // Check if permission is already attached to avoid duplicates
+        if (! $role->permissions()->where('permission_id', $permission->id)->exists()) {
+            $role->permissions()->attach($permission->id);
+        }
+        $user->roles()->attach($role->id);
+
+        // Cache initial permissions
+        $user->getCachedPermissions();
+        expect(Cache::has('user_permissions_'.$user->id.'_v1'))->toBeTrue();
+
+        // Act - Update role permissions
+        $role->update(['name' => 'Updated Author']);
+
+        // Assert - New cache should be created with updated data
+        $user->getCachedPermissions();
+        expect(Cache::has('user_permissions_'.$user->id.'_v2'))->toBeTrue();
+    });
+
+    it('handles role deletion correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Cache initial data
+        $user->getCachedRoles();
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+
+        // Act - Delete role
+        $role->delete();
+
+        // Assert - Cache should be invalidated (new version created)
+        $user->getCachedRoles();
+        expect(Cache::has('user_roles_'.$user->id.'_v2'))->toBeTrue();
+    });
+
+    it('handles user deletion correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Cache initial data
+        $user->getCachedRoles();
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+
+        // Act - Delete user
+        $user->delete();
+
+        // Assert - Cache should be cleared
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeFalse();
+    });
+
+    it('handles multiple users with same role efficiently', function () {
+        // Arrange
+        $users = User::factory()->count(5)->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+
+        foreach ($users as $user) {
+            $user->roles()->attach($role->id);
+        }
+
+        // Cache data for all users
+        foreach ($users as $user) {
+            $user->getCachedRoles();
+            expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+        }
+
+        // Act - Update role (should invalidate all user caches efficiently)
+        $role->update(['name' => 'Updated Author']);
+
+        // Assert - New caches should be created with new version
+        $users[0]->getCachedRoles();
+        expect(Cache::has('user_roles_'.$users[0]->id.'_v2'))->toBeTrue();
+    });
+
+    it('handles complex permission scenarios', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $authorRole = Role::where('name', UserRole::AUTHOR->value)->first();
+        $editorRole = Role::where('name', UserRole::EDITOR->value)->first();
+
+        $publishPermission = Permission::where('name', 'publish_posts')->first();
+        $editPermission = Permission::where('name', 'edit_posts')->first();
+        $deletePermission = Permission::where('name', 'delete_posts')->first();
+
+        // Check if permissions are already attached to avoid duplicates
+        if (! $authorRole->permissions()->where('permission_id', $publishPermission->id)->exists()) {
+            $authorRole->permissions()->attach($publishPermission->id);
+        }
+        if (! $authorRole->permissions()->where('permission_id', $editPermission->id)->exists()) {
+            $authorRole->permissions()->attach($editPermission->id);
+        }
+        if (! $editorRole->permissions()->where('permission_id', $editPermission->id)->exists()) {
+            $editorRole->permissions()->attach($editPermission->id);
+        }
+        if (! $editorRole->permissions()->where('permission_id', $deletePermission->id)->exists()) {
+            $editorRole->permissions()->attach($deletePermission->id);
+        }
+
+        $user->roles()->attach([$authorRole->id, $editorRole->id]);
+
+        // Act
+        $cachedPermissions = $user->getCachedPermissions();
+
+        // Assert - Should have unique permissions from both roles
+        expect($cachedPermissions)->toContain('publish_posts');
+        expect($cachedPermissions)->toContain('edit_posts');
+        expect($cachedPermissions)->toContain('delete_posts');
+        expect(count($cachedPermissions))->toBeGreaterThanOrEqual(3); // At least 3 unique permissions
+    });
+
+    it('handles empty permission arrays correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Act
+        $hasAny = $user->hasAnyCachedPermission([]);
+        $hasAll = $user->hasAllCachedPermissions([]);
+
+        // Assert
+        expect($hasAny)->toBeFalse();
+        expect($hasAll)->toBeTrue(); // Empty array means user has all required permissions
+    });
+
+    it('handles empty role arrays correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Act
+        $hasAny = $user->hasAnyCachedRole([]);
+        $hasAll = $user->hasAllCachedRoles([]);
+
+        // Assert
+        expect($hasAny)->toBeFalse();
+        expect($hasAll)->toBeTrue(); // Empty array means user has all required roles
+    });
+
+    it('handles non-existent permissions correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Act
+        $hasPermission = $user->hasCachedPermission('non_existent_permission');
+        $hasAny = $user->hasAnyCachedPermission(['non_existent_permission', 'another_fake']);
+        $hasAll = $user->hasAllCachedPermissions(['non_existent_permission']);
+
+        // Assert
+        expect($hasPermission)->toBeFalse();
+        expect($hasAny)->toBeFalse();
+        expect($hasAll)->toBeFalse();
+    });
+
+    it('handles non-existent roles correctly', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $user->roles()->attach($role->id);
+
+        // Act
+        $hasRole = $user->hasCachedRole('non_existent_role');
+        $hasAny = $user->hasAnyCachedRole(['non_existent_role', 'another_fake']);
+        $hasAll = $user->hasAllCachedRoles(['non_existent_role']);
+
+        // Assert
+        expect($hasRole)->toBeFalse();
+        expect($hasAny)->toBeFalse();
+        expect($hasAll)->toBeFalse();
+    });
+});

--- a/tests/Feature/Services/UserServiceTest.php
+++ b/tests/Feature/Services/UserServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Constants\CacheKeys;
+use App\Enums\UserRole;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use App\Services\UserService;
+use Illuminate\Support\Facades\Cache;
+
+describe('UserService Caching', function () {
+    beforeEach(function () {
+        // Clear all caches before each test
+        Cache::flush();
+    });
+
+    it('caches roles and permissions when getting user by ID', function () {
+        // Arrange
+        $userService = new UserService;
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+        $permission = Permission::where('name', 'publish_posts')->first();
+
+        // Check if permission is already attached to avoid duplicates
+        if (! $role->permissions()->where('permission_id', $permission->id)->exists()) {
+            $role->permissions()->attach($permission->id);
+        }
+        $user->roles()->attach($role->id);
+
+        // Act
+        $retrievedUser = $userService->getUserById($user->id);
+
+        // Assert
+        expect($retrievedUser->id)->toBe($user->id);
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+        expect(Cache::has('user_permissions_'.$user->id.'_v1'))->toBeTrue();
+    });
+
+    it('caches all roles with permissions', function () {
+        // Arrange
+        $userService = new UserService;
+
+        // Act
+        $roles = $userService->getAllRoles();
+
+        // Assert
+        expect($roles)->not->toBeEmpty();
+        expect(Cache::has(CacheKeys::ALL_ROLES_CACHE_KEY))->toBeTrue();
+    });
+
+    it('caches all permissions', function () {
+        // Arrange
+        $userService = new UserService;
+
+        // Act
+        $permissions = $userService->getAllPermissions();
+
+        // Assert
+        expect($permissions)->not->toBeEmpty();
+        expect(Cache::has(CacheKeys::ALL_PERMISSIONS_CACHE_KEY))->toBeTrue();
+    });
+
+    it('clears user cache when assigning roles', function () {
+        // Arrange
+        $userService = new UserService;
+        $user = User::factory()->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+
+        // Cache some data first
+        $user->getCachedRoles();
+        expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+
+        // Act
+        $updatedUser = $userService->assignRoles($user->id, [$role->id]);
+
+        // Assert
+        expect($updatedUser->id)->toBe($user->id);
+        expect($updatedUser->roles)->toHaveCount(1);
+    });
+
+    it('pre-warms caches for users in pagination', function () {
+        // Arrange
+        $userService = new UserService;
+        $users = User::factory()->count(3)->create();
+        $role = Role::where('name', UserRole::AUTHOR->value)->first();
+
+        foreach ($users as $user) {
+            $user->roles()->attach($role->id);
+        }
+
+        // Act
+        $paginator = $userService->getUsersWithWarmedCaches(['per_page' => 2]);
+
+        // Assert
+        expect($paginator->total())->toBeGreaterThanOrEqual(3); // At least 3 users (including seeded ones)
+        expect($paginator->items())->toHaveCount(2); // First page
+
+        // Check that caches are warmed for first page users
+        foreach ($paginator->items() as $user) {
+            expect(Cache::has('user_roles_'.$user->id.'_v1'))->toBeTrue();
+            expect(Cache::has('user_permissions_'.$user->id.'_v1'))->toBeTrue();
+        }
+    });
+
+    it('increments cache version correctly', function () {
+        // Arrange
+        $userService = new UserService;
+        $initialVersion = Cache::get('user_cache_version', 1);
+        expect($initialVersion)->toBe(1);
+
+        // Act
+        $userService->incrementCacheVersion();
+
+        // Assert
+        $newVersion = Cache::get('user_cache_version');
+        expect($newVersion)->toBe(2);
+    });
+});


### PR DESCRIPTION
Introduces comprehensive caching for user roles and permissions to optimize authorization performance and reduce database queries.

### Changes
**Commit:** [`4d75d97`](https://github.com/mubbi/laravel-blog-api/commit/4d75d974b84154887483fcde29860e628e4f2f0f) - perf: roles permissions cache

### Files Modified
#### 🆕 New Files
- [`app/Traits/HasCachedRolesAndPermissions.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/app/Traits/HasCachedRolesAndPermissions.php) - Core caching trait with role/permission methods
- [`app/Constants/CacheKeys.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/app/Constants/CacheKeys.php) - Centralized cache key management
- [`app/Console/Commands/ClearRolePermissionCache.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/app/Console/Commands/ClearRolePermissionCache.php) - Cache management console command

#### 🔧 Modified Files
- [`app/Models/User.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/app/Models/User.php) - Added caching trait integration
- [`app/Models/Role.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/app/Models/Role.php) - Enhanced with caching support
- [`app/Services/UserService.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/app/Services/UserService.php) - Updated to use cached methods
- [`app/Http/Resources/V1/Auth/UserResource.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/app/Http/Resources/V1/Auth/UserResource.php) - Optimized data retrieval
- [`database/migrations/2025_07_04_205615_create_role_user_table.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/database/migrations/2025_07_04_205615_create_role_user_table.php)
- [`database/migrations/2025_07_04_205616_create_permission_role_table.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/database/migrations/2025_07_04_205616_create_permission_role_table.php)

#### 🧪 Test Files Added
- [`tests/Feature/Console/ClearRolePermissionCacheTest.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/tests/Feature/Console/ClearRolePermissionCacheTest.php) - Console command tests
- [`tests/Feature/Models/UserCachingTest.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/tests/Feature/Models/UserCachingTest.php) - User caching functionality tests
- [`tests/Feature/Services/UserServiceTest.php`](https://github.com/mubbi/laravel-blog-api/blob/4d75d974b84154887483fcde29860e628e4f2f0f/tests/Feature/Services/UserServiceTest.php) - Service layer integration tests

### Key Features
- **Cached Role/Permission Checks**: `hasCachedPermission()`, `hasCachedRole()`, etc.
- **Bulk Permission Checks**: `hasAnyCachedPermission()`, `hasAllCachedPermissions()`
- **Cache Management**: Console command with `--user-id` and `--all` options
- **Version-based Invalidation**: Efficient bulk cache clearing
- **1-hour TTL**: Configurable cache duration

### Stats
- **+1,162 lines** added
- **12 files** changed
- **632+ lines** of comprehensive tests
- **Zero breaking changes**

### Usage
```bash
# Clear all user caches
php artisan cache:clear-roles-permissions --all
```

# Clear specific user cache
```bash
php artisan cache:clear-roles-permissions --user-id=1
```
Testing
```bash
php artisan test tests/Feature/Models/UserCachingTest.php
php artisan test tests/Feature/Console/ClearRolePermissionCacheTest.php
php artisan test tests/Feature/Services/UserServiceTest.php
```